### PR TITLE
Switch to more recent Travis-CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,34 +1,11 @@
-## Sample .travis.yml file for use with metacran/r-builder
-## See https://github.com/metacran/r-builder for details.
+language: r
+sudo: false
+cache: packages
 
-language: c
-sudo: required
-
-before_install:
-  - curl -OL https://raw.githubusercontent.com/metacran/r-builder/master/pkg-build.sh
-  - chmod 755 pkg-build.sh
-  - ./pkg-build.sh bootstrap
-
-install:
-  - ./pkg-build.sh install_deps
-  - ./pkg-build.sh install_github jimhester/covr
-
-script:
-  - ./pkg-build.sh run_tests
-
-after_failure:
-  - ./pkg-build.sh dump_logs
+r:
+ - release
+ - devel
+ - oldrel
 
 after_success:
-  - if [[ ! -z "$COVERAGE" ]];then ./pkg-build.sh run_script -e 'covr::codecov()'; fi
-
-notifications:
-  email:
-    on_success: change
-    on_failure: change
-
-env:
-  matrix:
-    - RVERSION=release
-    - RVERSION=devel COVERAGE=yes
-
+  - Rscript -e 'covr::codecov()'


### PR DESCRIPTION
I believe this failure (https://travis-ci.org/MangoTheCat/goodpractice/jobs/238101704, `"This R version is not available for this CI"`) is due to an old Travis config, so I updated to a simple recent one.