### PR TITLE
Fixes spurious failing test on travis

### DIFF
--- a/tests/testthat/test-integrity.R
+++ b/tests/testthat/test-integrity.R
@@ -7,7 +7,7 @@ test_that("checks are not overwritten", {
   
   pkgdir <- file.path("..", "..", "R")
   rfiles <- list.files(pkgdir, full.names = TRUE)
-  rlines <- unlist(lapply(rfiles, readLines))
+  rlines <- as.character(unlist(lapply(rfiles, readLines)))
   rwords <- unlist(strsplit(rlines, "\\s+"))
   checks <- grep("CHECKS$", rwords, fixed = TRUE, value = TRUE)
   expect_false(any(duplicated(checks)))


### PR DESCRIPTION
This should fix the following error on travis:

```
  > test_check("goodpractice")
  1. Error: checks are not overwritten (@test-integrity.R#11) --------------------
  non-character argument
  1: unlist(strsplit(rlines, "\\s+")) at testthat/test-integrity.R:11
  2: strsplit(rlines, "\\s+")
```