### PR TITLE
Fix 59 handle delegated tasks

### DIFF
--- a/R/chk_covr.R
+++ b/R/chk_covr.R
@@ -17,9 +17,12 @@ CHECKS$covr <- make_check(
   },
 
   check = function(state) {
+    if(inherits(state$covr, "try-error"))
+      return(list(status = NA, positions = list()))
+    
     zero <- state$covr$zero
     if (NROW(zero) == 0) return(list(status = TRUE, positions = list()))
-
+    
     positions <- lapply(seq_len(NROW(zero)), function(i) {
       list(
         filename = zero$filename[i],
@@ -29,7 +32,7 @@ CHECKS$covr <- make_check(
         line = NA_character_
       )
     })
-
+    
     list(status = FALSE, positions = positions)
   }
 )

--- a/R/chk_cyclocomp.R
+++ b/R/chk_cyclocomp.R
@@ -24,6 +24,7 @@ CHECKS$cyclocomp <- make_check(
   },
 
   check = function(state) {
+    if(inherits(state$cyclocomp, "try-error")) return(NA)
     all(state$cyclocomp$cyclocomp <= cyclocomp_limit)
   }
 )

--- a/R/chk_description.R
+++ b/R/chk_description.R
@@ -12,6 +12,8 @@ CHECKS$no_description_depends <- make_check(
         instead.',
 
   check = function(state) {
+    if(inherits(state$description, "try-error")) return(NA)
+    
     deps <- state$description$get_deps()
     ## Remove 'methods' and R, these are OK
     deps <- deps[! deps$package %in% c("methods", "R"), , drop = FALSE]
@@ -32,6 +34,8 @@ CHECKS$no_description_date <- make_check(
         the package when you perform `R CMD build` on it.',
 
   check = function(state) {
+    if(inherits(state$description, "try-error")) return(NA)
+    
     ! state$description$has_fields('Date')
   }
 )
@@ -49,6 +53,8 @@ CHECKS$description_url <- make_check(
         add an URL to GitHub, or the CRAN package package page.',
 
   check = function(state) {
+    if(inherits(state$description, "try-error")) return(NA)
+    
     state$description$has_fields("URL")
   }
 )
@@ -66,6 +72,8 @@ CHECKS$description_bugreports <- make_check(
         for free, https://github.com, https://gitlab.com, etc.',
 
   check = function(state) {
+    if(inherits(state$description, "try-error")) return(NA)
+    
     state$description$has_fields('BugReports')
   }
 )

--- a/R/chk_lintr.R
+++ b/R/chk_lintr.R
@@ -4,6 +4,8 @@ get_lintr_position <- function(linter) {
 }
 
 get_lintr_state <- function(state, linter) {
+  if(inherits(state$lintr, "try-error")) return(list(status = NA, position = list()))
+  
   linters <- vapply(state$lintr, "[[", "", "linter")
   list(
     status = ! linter %in% linters,
@@ -122,6 +124,8 @@ CHECKS$lintr_library_require_linter <- make_check(
         them as 'Depends' dependencies.",
 
   check = function(state) {
+    if(inherits(state$lintr, "try-error")) return(list(status = NA, position = list()))
+    
     res <- get_lintr_state(state, "library_require_linter")
 
     ## library() and require() are OK in tests and vignettes

--- a/R/chk_namespace.R
+++ b/R/chk_namespace.R
@@ -12,6 +12,7 @@ CHECKS$no_import_package_as_a_whole <- make_check(
         only the specific functions you need.',
 
   check = function(state) {
+    if(inherits(state$namespace, "try-error")) return(NA)
     imports <- state$namespace$imports
     all(vapply(imports, length, 1L) > 1)
   }
@@ -29,6 +30,7 @@ CHECKS$no_export_pattern <- make_check(
         package.',
 
   check = function(state) {
+    if(inherits(state$namespace, "try-error")) return(NA)
     length(state$namespace$exportPatterns) == 0
   }
 )

--- a/R/chk_rcmdcheck.R
+++ b/R/chk_rcmdcheck.R
@@ -39,6 +39,7 @@ make_rcmd_check <- function(
       )
     },
     check = function(state) {
+      if(inherits(state$rcmdcheck, "try-error")) return(NA)
       ! any(grep(pattern, state$rcmdcheck[[type]]))
     }
   )

--- a/R/gp.R
+++ b/R/gp.R
@@ -57,7 +57,8 @@ gp <- function(path = ".", checks = all_checks(), extra_preps = NULL,
 }
 
 check_passed <- function(chk) {
-  isTRUE(chk) || ("status" %in% names(chk) && isTRUE(chk[["status"]]))
+  isTRUE(chk) || ("status" %in% names(chk) && isTRUE(chk[["status"]])) || 
+    is.na(chk) || ("status" %in% names(chk) && is.na(chk[["status"]]))
 }
 
 check_failed <- function(chk) {

--- a/R/prep_covr.R
+++ b/R/prep_covr.R
@@ -7,7 +7,7 @@ PREPS$covr <- function(state, path = state$path, quiet) {
   covr <- try(list(coverage = package_coverage(path, quiet = quiet)), silent = quiet)
   
   if (inherits(covr, "try-error")) {
-    warning("Test coverage could not be calculated.")
+    warning("Prep step for test coverage failed.")
   } else {
     with_options(
       list(covr.rstudio_source_markers = FALSE),

--- a/R/prep_covr.R
+++ b/R/prep_covr.R
@@ -4,13 +4,19 @@
 #' @importFrom withr with_options
 
 PREPS$covr <- function(state, path = state$path, quiet) {
-  covr <- list(coverage = package_coverage(path, quiet = quiet))
-  with_options(
-    list(covr.rstudio_source_markers = FALSE),
-    covr$zero <- zero_coverage(covr$coverage)
-  )
-  covr$pct_by_line <- percent_coverage(covr$coverage, by = "line")
-  covr$pct_by_expr <- percent_coverage(covr$coverage, by = "expression")
+  covr <- try(list(coverage = package_coverage(path, quiet = quiet)))
+  
+  if (inherits(covr, "try-error")) {
+    warning("Test coverage could not be calculated.")
+  } else {
+    with_options(
+      list(covr.rstudio_source_markers = FALSE),
+      covr$zero <- zero_coverage(covr$coverage)
+    )
+    covr$pct_by_line <- percent_coverage(covr$coverage, by = "line")
+    covr$pct_by_expr <- percent_coverage(covr$coverage, by = "expression")
+  }
+  
   state$covr <- covr
   state
 }

--- a/R/prep_covr.R
+++ b/R/prep_covr.R
@@ -4,7 +4,7 @@
 #' @importFrom withr with_options
 
 PREPS$covr <- function(state, path = state$path, quiet) {
-  covr <- try(list(coverage = package_coverage(path, quiet = quiet)))
+  covr <- try(list(coverage = package_coverage(path, quiet = quiet)), silent = quiet)
   
   if (inherits(covr, "try-error")) {
     warning("Test coverage could not be calculated.")

--- a/R/prep_cyclocomp.R
+++ b/R/prep_cyclocomp.R
@@ -3,6 +3,7 @@
 #' @importFrom cyclocomp cyclocomp_package_dir
 
 PREPS$cyclocomp <- function(state, path = state$path, quiet) {
-  state$cyclocomp <- cyclocomp_package_dir(path)
+  state$cyclocomp <- try(cyclocomp_package_dir(path), silent = quiet)
+  if(inherits(state$cyclocomp, "try-error")) warning("Prep step for cyclomatic complexity failed.")
   state
 }

--- a/R/prep_description.R
+++ b/R/prep_description.R
@@ -3,6 +3,7 @@
 #' @importFrom desc description
 
 PREPS$description <- function(state, path = state$path, quiet) {
-  state$description <- description$new(file.path(path, "DESCRIPTION"))
+  state$description <- try(description$new(file.path(path, "DESCRIPTION")), silent = quiet)
+  if(inherits(state$description, "try-error")) warning("Prep step for description failed.")
   state
 }

--- a/R/prep_lintr.R
+++ b/R/prep_lintr.R
@@ -18,7 +18,8 @@ linters_to_lint <- list(
 PREPS$lintr <- function(state, path = state$path, quiet) {
   path <- normalizePath(path)
   suppressMessages(
-    state$lintr <- lint_package(path, linters = linters_to_lint)
+    state$lintr <- try(lint_package(path, linters = linters_to_lint), silent = TRUE)
   )
+  if(inherits(state$lintr, "try-error")) warning("Prep step for linter failed.")
   state
 }

--- a/R/prep_namespace.R
+++ b/R/prep_namespace.R
@@ -3,9 +3,10 @@
 
 PREPS$namespace <- function(state, path = state$path, quiet) {
   path <- normalizePath(path)
-  state$namespace <- parseNamespaceFile(
+  state$namespace <- try(parseNamespaceFile(
     basename(path),
     file.path(path, "..")
-  )
+  ), silent = quiet)
+  if(inherits(state$namespace, "try-error")) warning("Prep step for namespace failed.")
   state
 }

--- a/R/prep_rcmdcheck.R
+++ b/R/prep_rcmdcheck.R
@@ -4,6 +4,7 @@
 
 PREPS$rcmdcheck <- function(state, path = state$path, quiet) {
   path <- normalizePath(path)
-  state$rcmdcheck <- rcmdcheck(path, quiet = quiet)
+  state$rcmdcheck <- try(rcmdcheck(path, quiet = quiet), silent = quiet)
+  if(inherits(state$rcmdcheck, "try-error")) warning("Prep step for rcmdcheck failed.")
   state
 }


### PR DESCRIPTION
Suggested fix for #59, also related to #57 

The prep steps are now wrapped in a try environment. If the prep steps fails
* a warning is issued
* the result of the corresponding check(s) is NA

In the print method for `gp` objects, a test result of NA is treated like a passed test so that only failed tests show up in the print output.