### PR TITLE
include (additional) custom checks

### DIFF
--- a/R/gp.R
+++ b/R/gp.R
@@ -26,6 +26,7 @@ gp <- function(path = ".", checks = all_checks(), extra_preps = NULL,
   MYPREPS <- prepare_preps(PREPS, extra_preps)
   MYCHECKS <- prepare_checks(CHECKS, extra_checks)
 
+  checks <- unique(c(checks, names(extra_checks)))
   preps <- unique(unlist(lapply(MYCHECKS[checks], "[[", "preps")))
 
   if(file.exists(file.path(path, "DESCRIPTION"))) {

--- a/tests/testthat/test-custom.R
+++ b/tests/testthat/test-custom.R
@@ -13,7 +13,7 @@ test_that("extra check", {
     check = function(state) state$desc$has_fields("URL")
   )
 
-  res <- gp("bad1", checks = c("url", "no_description_depends"),
+  res <- gp("bad1", checks = "no_description_depends",
             extra_preps = list(desc = make_prep("desc", url_prep)),
-            extra_checks = list(url = url_chk))
+            extra_checks = list("url" = url_chk))
 })


### PR DESCRIPTION
The argument `checks` to `gp()` now(?) only refers to the checks in `CHECKS` and additional checks need to be provided in a named list via `extra_checks`.