### PR TITLE
fix the failing test for lintr_library_require_linter on windows

### DIFF
--- a/R/chk_lintr.R
+++ b/R/chk_lintr.R
@@ -130,7 +130,7 @@ CHECKS$lintr_library_require_linter <- make_check(
 
     ## library() and require() are OK in tests and vignettes
     res$positions <- Filter(
-      f = function(x) grepl("^R/", x$filename),
+      f = function(x) grepl("^R[/(\\)]", x$filename),
       res$positions
     )
     res$status <- length(res$positions) == 0


### PR DESCRIPTION
only calls to `library()` or `require()` in the `R` folder are not okay. the regex for the folder wasn't working on windows because it can be `R\\` instead of `R/`