### PR TITLE
lets print.gp control how many positions are shown

### DIFF
--- a/R/print.R
+++ b/R/print.R
@@ -1,11 +1,11 @@
-
+#' @param positions_limit how many positions to print at most.
 #' @export
 #' @importFrom rstudioapi hasFun
 #' @importFrom praise praise
 #' @importFrom clisymbols symbol
 #' @importFrom crayon red bold
 
-print.goodPractice <- function(x, ...) {
+print.goodPractice <- function(x, positions_limit = 5, ...) {
 
   failure <- FALSE
 
@@ -15,7 +15,7 @@ print.goodPractice <- function(x, ...) {
         failure <- TRUE
         gp_header(x)
       }
-      gp_advice(x, check)
+      gp_advice(x, check, positions_limit)
     }
   }
 
@@ -95,7 +95,7 @@ gp_footer <- function(x) {
 
 #' @importFrom clisymbols symbol
 
-gp_advice <- function(state, fail) {
+gp_advice <- function(state, fail, limit) {
 
   MYCHECKS <- prepare_checks(CHECKS, state$extra_checks)
 
@@ -116,15 +116,15 @@ gp_advice <- function(state, fail) {
 
   cat(str)
 
-  if ("positions" %in% names(res)) gp_positions(res[["positions"]])
+  if ("positions" %in% names(res)) gp_positions(res[["positions"]], limit)
 
   cat("\n")
 }
 
-gp_positions <- function(pos, limit = 5) {
+gp_positions <- function(pos, limit) {
 
   num <- length(pos)
-  if (length(pos) > limit) pos <- pos[1:5]
+  if (length(pos) > limit) pos <- pos[1:limit]
 
   cat("\n\n")
   lapply(pos, function(x) {
@@ -134,7 +134,7 @@ gp_positions <- function(pos, limit = 5) {
   })
 
   if (num > limit) {
-    and <- paste0("    ... and ", num - 5, " more lines\n")
+    and <- paste0("    ... and ", num - limit, " more lines\n")
     cat(crayon::blue(and))
   }
 }


### PR DESCRIPTION
closes #130. new positions_limit argument to print.gp
``` r
devtools::load_all("~/goodpractice")
#> Loading goodpractice
gp_lintrs <- c("lintr_assignment_linter", "lintr_line_length_linter", 
               "lintr_trailing_semicolon_linter", 
               "lintr_attach_detach_linter", "lintr_setwd_linter", 
               "lintr_sapply_linter", "lintr_library_require_linter", 
               "lintr_seq_linter")
bad2 <- system.file(c("tests/testthat/bad2"), package= "goodpractice")
print(
  gp(bad2, checks = gp_lintrs), 
  positions_limit = 1)
#> Preparing: lintr
#> ── GP badpackage ──────────────────────────────────────────────────────────
#> 
#> It is good practice to
#> 
#>   ✖ avoid the attach() and detach() functions, they are fragile
#>     and code that uses them will probably break sooner than later.
#> 
#>     R/attach.R:3:3
#>     ... and 1 more lines
#> 
#>   ✖ avoid calling setwd(), it changes the global environment. If
#>     you need it, consider using on.exit() to restore the working
#>     directory.
#> 
#>     R/attach.R:9:3
#> 
#>   ✖ avoid sapply(), it is not type safe. It might return a vector,
#>     or a list, depending on the input data. Consider using
#>     vapply() instead.
#> 
#>     R/attach.R:13:3
#>     ... and 1 more lines
#> 
#>   ✖ avoid the library() and require() functions, they change the
#>     global search path. If you need to use other packages, import
#>     them. If you need to load them explicitly, then consider
#>     loadNamespace() instead, or as a last resort, declare them as
#>     'Depends' dependencies.
#> 
#>     R/attach.R:18:3
#>     ... and 1 more lines
#> 
#> ───────────────────────────────────────────────────────────────────────────
```

<sup>Created on 2019-08-19 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>
