### PR TITLE
makes cyclocomp limit user-settable

### DIFF
--- a/R/chk_cyclocomp.R
+++ b/R/chk_cyclocomp.R
@@ -20,7 +20,7 @@ CHECKS$cyclocomp <- make_check(
     )
     paste0(
       "write short and simple functions. These functions have high
-       cyclomatic complexity (>", cyclocomp_limit,"): ", funcs, ".",
+       cyclomatic complexity (>", cyclocomp_limit,"): ", funcs, ". ",
       "You can make them easier to reason about by encapsulating distinct steps
       of your function into subfunctions."
     )

--- a/R/chk_cyclocomp.R
+++ b/R/chk_cyclocomp.R
@@ -1,7 +1,7 @@
 
 #' @include lists.R
 
-cyclocomp_limit <- 50
+
 
 CHECKS$cyclocomp <- make_check(
 
@@ -10,6 +10,7 @@ CHECKS$cyclocomp <- make_check(
   preps = "cyclocomp",
 
   gp = function(state) {
+    cyclocomp_limit <- getOption("gp.cyclocomp.limit", 50)
     cyc <- state$cyclocomp
     long <- which(cyc$cyclocomp > cyclocomp_limit)
     funcs <- paste0(
@@ -19,12 +20,15 @@ CHECKS$cyclocomp <- make_check(
     )
     paste0(
       "write short and simple functions. These functions have high
-       cyclomatic complexity:", funcs, "."
+       cyclomatic complexity (>", cyclocomp_limit,"): ", funcs, ".",
+      "You can make them easier to reason about by encapsulating distinct steps
+      of your function into subfunctions."
     )
   },
 
   check = function(state) {
-    if(inherits(state$cyclocomp, "try-error")) return(NA)
+    cyclocomp_limit <- getOption("gp.cyclocomp.limit", 50)
+    if (inherits(state$cyclocomp, "try-error")) return(NA)
     all(state$cyclocomp$cyclocomp <= cyclocomp_limit)
   }
 )


### PR DESCRIPTION
via options()$gp.cyclocomp.limit, still defaults to 50.

Personally, I think that 50 is way too high -- anything above 10 becomes rather hard to understand, I think, and should be made more legible by encapsulation or by removing/simplifying conditionals.
Glad to change the modified gp-message if you have other preferences.

``` r
devtools::load_all("~/lehre/goodpractice")
#> Loading goodpractice
bad1 <- system.file("bad1", package= "goodpractice")
gp(bad1, checks = "cyclocomp")
#> Preparing: cyclocomp
#> 
#>   
[...]
#> ─  building ‘badpackage_1.0.0.tar.gz’
#> 
  
   
#> 
#> 
#> ♥ Yippie! Exceptional package! Keep up the bedazzling work!
#> #--------------------------------------------------------------------------------------

options(gp.cyclocomp.limit = 1)
gp(bad1, checks = "cyclocomp")
#> Preparing: cyclocomp
[...]
#> ─  building ‘badpackage_1.0.0.tar.gz’
#> 
  
   
#> 
#> ── GP badpackage ──────────────────────────────────────────────────────────
#> 
#> It is good practice to
#> 
#>   ✖ write short and simple functions. These functions have high
#>     cyclomatic complexity (>1): tf (2).You can make them easier to
#>     reason about by encapsulating distinct steps of your function
#>     into subfunctions.
#> ───────────────────────────────────────────────────────────────────────────
```

<sup>Created on 2019-08-19 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>

<details>

<summary>Session info</summary>

``` r
devtools::session_info()
#> ─ Session info ──────────────────────────────────────────────────────────
#>  setting  value                       
#>  version  R version 3.5.3 (2019-03-11)
#>  os       Linux Mint 19.1             
#>  system   x86_64, linux-gnu           
#>  ui       X11                         
#>  language en_GB                       
#>  collate  en_GB.UTF-8                 
#>  ctype    en_GB.UTF-8                 
#>  tz       Europe/Berlin               
#>  date     2019-08-19                  
#> 
#> ─ Packages ──────────────────────────────────────────────────────────────
#>  ! package      * version    date       lib
#>    assertthat     0.2.1      2019-03-21 [1]
#>    backports      1.1.4      2019-04-10 [1]
#>    callr          3.3.1      2019-07-18 [1]
#>    cli            1.1.0      2019-03-19 [1]
#>    clisymbols     1.2.0      2017-05-21 [1]
#>    covr           3.3.0      2019-08-06 [1]
#>    crayon         1.3.4      2017-09-16 [1]
#>    curl           4.0        2019-07-22 [1]
#>    cyclocomp      1.1.0      2016-09-10 [1]
#>    desc           1.2.0      2018-05-01 [1]
#>    devtools       2.0.2      2019-04-08 [1]
#>    digest         0.6.20     2019-07-04 [1]
#>    evaluate       0.14       2019-05-28 [1]
#>    fs             1.3.1      2019-05-06 [1]
#>    glue           1.3.1      2019-03-12 [1]
#>  P goodpractice * 1.0.2.9000 2019-08-16 [?]
#>    highr          0.8        2019-03-20 [1]
#>    htmltools      0.3.6      2017-04-28 [1]
#>    httr           1.4.1      2019-08-05 [1]
#>    jsonlite       1.6        2018-12-07 [1]
#>    knitr          1.24       2019-08-08 [1]
#>    lazyeval       0.2.2      2019-03-15 [1]
#>    lintr          1.0.3      2018-11-08 [1]
#>    magrittr       1.5        2014-11-22 [1]
#>    memoise        1.1.0      2017-04-21 [1]
#>    pkgbuild       1.0.4      2019-08-05 [1]
#>    pkgload        1.0.2      2018-10-29 [1]
#>    praise         1.0.0      2015-08-11 [1]
#>    prettyunits    1.0.2      2015-07-13 [1]
#>    processx       3.4.1      2019-07-18 [1]
#>    ps             1.3.0      2018-12-21 [1]
#>    R6             2.4.0      2019-02-14 [1]
#>    rcmdcheck      1.3.3      2019-05-07 [1]
#>    Rcpp           1.0.2      2019-07-25 [1]
#>    remotes        2.1.0      2019-06-24 [1]
#>    rex            1.1.2      2017-10-19 [1]
#>    rlang          0.4.0      2019-06-25 [1]
#>    rmarkdown      1.13       2019-05-22 [1]
#>    rprojroot      1.3-2      2018-01-03 [1]
#>    rstudioapi     0.10       2019-03-19 [1]
#>    sessioninfo    1.1.1      2018-11-05 [1]
#>    stringi        1.4.3      2019-03-12 [1]
#>    stringr        1.4.0      2019-02-10 [1]
#>    testthat     * 2.2.1      2019-07-25 [1]
#>    usethis        1.5.0      2019-04-07 [1]
#>    whoami         1.3.0      2019-03-19 [1]
#>    withr          2.1.2      2018-03-15 [1]
#>    xfun           0.8        2019-06-25 [1]
#>    xml2           1.2.2      2019-08-09 [1]
#>    xmlparsedata   1.0.2      2018-09-17 [1]
#>    xopen          1.0.0      2018-09-17 [1]
#>    yaml           2.2.0      2018-07-25 [1]
#>  source                                   
#>  CRAN (R 3.5.3)                           
#>  CRAN (R 3.5.3)                           
#>  CRAN (R 3.5.3)                           
#>  CRAN (R 3.5.3)                           
#>  CRAN (R 3.5.3)                           
#>  CRAN (R 3.5.3)                           
#>  CRAN (R 3.5.3)                           
#>  CRAN (R 3.5.3)                           
#>  CRAN (R 3.5.3)                           
#>  CRAN (R 3.5.3)                           
#>  CRAN (R 3.5.3)                           
#>  CRAN (R 3.5.3)                           
#>  CRAN (R 3.5.3)                           
#>  CRAN (R 3.5.3)                           
#>  CRAN (R 3.5.3)                           
#>  Github (MangoTheCat/goodpractice@f315d32)
#>  CRAN (R 3.5.3)                           
#>  CRAN (R 3.5.3)                           
#>  CRAN (R 3.5.3)                           
#>  CRAN (R 3.5.3)                           
#>  CRAN (R 3.5.3)                           
#>  CRAN (R 3.5.3)                           
#>  CRAN (R 3.5.3)                           
#>  CRAN (R 3.5.3)                           
#>  CRAN (R 3.5.3)                           
#>  CRAN (R 3.5.3)                           
#>  CRAN (R 3.5.3)                           
#>  CRAN (R 3.5.3)                           
#>  CRAN (R 3.5.3)                           
#>  CRAN (R 3.5.3)                           
#>  CRAN (R 3.5.3)                           
#>  CRAN (R 3.5.3)                           
#>  CRAN (R 3.5.3)                           
#>  CRAN (R 3.5.3)                           
#>  CRAN (R 3.5.3)                           
#>  CRAN (R 3.5.3)                           
#>  CRAN (R 3.5.3)                           
#>  CRAN (R 3.5.3)                           
#>  CRAN (R 3.5.3)                           
#>  CRAN (R 3.5.3)                           
#>  CRAN (R 3.5.3)                           
#>  CRAN (R 3.5.3)                           
#>  CRAN (R 3.5.3)                           
#>  CRAN (R 3.5.3)                           
#>  CRAN (R 3.5.3)                           
#>  CRAN (R 3.5.3)                           
#>  CRAN (R 3.5.3)                           
#>  CRAN (R 3.5.3)                           
#>  CRAN (R 3.5.3)                           
#>  CRAN (R 3.5.3)                           
#>  CRAN (R 3.5.3)                           
#>  CRAN (R 3.5.3)                           
#> 
#> [1] /home/lmmista-wap218/R/x86_64-pc-linux-gnu-library/3.5
#> [2] /usr/local/lib/R/site-library
#> [3] /usr/lib/R/site-library
#> [4] /usr/lib/R/library
#> 
#>  P ── Loaded and on-disk path mismatch.
```

</details>

