### PR TITLE
Remove install-github.me as it is deprecated

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -35,13 +35,10 @@ You can install the release version from CRAN
 install.packages("goodpractice")
 ```
 
-and the development version from GitHub 
+and the development version from GitHub
 
 ```{r eval = FALSE}
-source("https://install-github.me/MangoTheCat/goodpractice")
-# or
-# install.packages("devtools")
-devtools::install_github("mangothecat/goodpractice") 
+remotes::install_github("mangothecat/goodpractice")
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -28,10 +28,7 @@ install.packages("goodpractice")
 and the development version from GitHub
 
 ``` r
-source("https://install-github.me/MangoTheCat/goodpractice")
-# or
-# install.packages("devtools")
-devtools::install_github("mangothecat/goodpractice") 
+remotes::install_github("mangothecat/goodpractice")
 ```
 
 ## Usage


### PR DESCRIPTION
Citing install-github.me: "Do not use this service, it is insecure. It is deprecated now, and will be defunct soon."