### PR TITLE
use cli_progress_step for check marks and time running prints

### DIFF
--- a/R/gp.R
+++ b/R/gp.R
@@ -53,8 +53,9 @@ gp <- function(
   )
 
   for (prep in preps) {
-    cli::cli_inform(c(i = "Preparing: {prep}"))
+    cli::cli_progress_step("Preparing: {prep}")
     state <- MYPREPS[[prep]](state, quiet = quiet)
+    cli::cli_progress_done()
   }
 
   state$checks <- list()


### PR DESCRIPTION
This is kind of a personal preference, but I really like progress step for this sort of messaging, because it switches to checkmark when its done and also give information on elapsed time per step.