### PR TITLE
Suppress expected warnings in goodpractice vignette

### DIFF
--- a/vignettes/goodpractice.Rmd
+++ b/vignettes/goodpractice.Rmd
@@ -40,11 +40,17 @@ library(goodpractice)
 
 # get path to example package
 pkg_path <- system.file("bad1", package = "goodpractice")
+```
 
+```{r, echo = TRUE, eval = FALSE}
 # run gp() on it
-# (covr and cyclocomp prep steps warn on this toy package)
+g <- gp(pkg_path)
+```
+```{r, echo = FALSE, eval = TRUE}
 g <- suppressWarnings(gp(pkg_path))
+```
 
+```{r}
 # show the result
 g
 ```


### PR DESCRIPTION
## Summary
- Wrap `gp()` call on the toy example package with `suppressWarnings()` to silence expected covr/cyclocomp prep step warnings

Closes #156

## Test plan
- [x] Vignette builds without R warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)