### PR TITLE
Rename results() column from 'result' to 'passed'

### DIFF
--- a/R/api.R
+++ b/R/api.R
@@ -21,7 +21,7 @@ checks <- function(gp) {
 #' @param gp \code{\link{gp}} output.
 #' @return Data frame, with columns:
 #' \item{check}{The name of the check.}
-#' \item{result}{Logical, whether it has failed or not.}
+#' \item{passed}{Logical, whether the check passed.}
 #'
 #' @family API
 #' @export
@@ -36,7 +36,7 @@ results <- function(gp) {
     stringsAsFactors = FALSE,
     row.names = NULL,
     check = names(gp$checks),
-    result = vapply(gp$checks, check_passed, TRUE)
+    passed = vapply(gp$checks, check_passed, TRUE)
   )
 }
 

--- a/man/results.Rd
+++ b/man/results.Rd
@@ -12,7 +12,7 @@ results(gp)
 \value{
 Data frame, with columns:
 \item{check}{The name of the check.}
-\item{result}{Logical, whether it has failed or not.}
+\item{passed}{Logical, whether the check passed.}
 }
 \description{
 Return all check results in a data frame

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -12,7 +12,7 @@ test_that("checks", {
 test_that("results", {
   res <- data.frame(
     check = c("covr", "description_bugreports"),
-    result = c(NA, FALSE),
+    passed = c(NA, FALSE),
     stringsAsFactors = FALSE
   )
   expect_equal(results(x), res)

--- a/tests/testthat/test-custom.R
+++ b/tests/testthat/test-custom.R
@@ -15,7 +15,7 @@ test_that("extra check", {
             extra_checks = list(simple_tf = simple_truefalse_not_tf))
 
   expect_equal(checks(res), "simple_tf")
-  expect_false(results(res)$result)
+  expect_false(results(res)$passed)
 
 })
 
@@ -36,6 +36,6 @@ test_that("extra prep and check pair", {
             extra_checks = list(url = url_chk))
 
   expect_equal(checks(res), c("no_description_depends", "url"))
-  expect_equal(results(res)$result, rep(FALSE, 2))
+  expect_equal(results(res)$passed, rep(FALSE, 2))
 
 })

--- a/tests/testthat/test-lintr.R
+++ b/tests/testthat/test-lintr.R
@@ -29,7 +29,7 @@ res_bad2 <- results(gp_bad2)
 gp_bad3 <- gp("bad3", checks = gp_lintrs)
 res_bad3 <- results(gp_bad3)
 
-get_result <- function(res, check) res$result[res$check == check]
+get_result <- function(res, check) res$passed[res$check == check]
 
 
 test_that("lintr_assignment_linter", {

--- a/tests/testthat/test-namespace.R
+++ b/tests/testthat/test-namespace.R
@@ -3,10 +3,10 @@ test_that("importing package as a whole is not okay", {
 
   bad1 <- system.file("bad1", package = "goodpractice")
   x <- gp(bad1, checks = "no_import_package_as_a_whole")
-  expect_false(results(x)$result)
+  expect_false(results(x)$passed)
 
   x <- gp("bad2", checks = "no_import_package_as_a_whole")
-  expect_true(results(x)$result)
+  expect_true(results(x)$passed)
 
 })
 
@@ -15,6 +15,6 @@ test_that("exportPattern is not okay", {
   # TODO expectation/example for "no_export_pattern" failing
 
   x <- gp("bad2", checks = "no_export_pattern")
-  expect_true(results(x)$result)
+  expect_true(results(x)$passed)
 
 })

--- a/tests/testthat/test-rcmdcheck.R
+++ b/tests/testthat/test-rcmdcheck.R
@@ -19,7 +19,7 @@
 #                                  "rcmdcheck_undefined_globals"))
 # res_bad2 <- results(gp_bad2)
 #
-# get_result <- function(res, check) res$result[res$check == check]
+# get_result <- function(res, check) res$passed[res$check == check]
 #
 #
 # test_that("rcmdcheck_package_dependencies_present", {
@@ -48,6 +48,6 @@
 #   expect_true(get_result(res_bad2, "rcmdcheck_missing_docs"))
 #
 #   x <- gp("baddoc", checks = "rcmdcheck_missing_docs")
-#   expect_false(results(x)$result)
+#   expect_false(results(x)$passed)
 #
 # })

--- a/tests/testthat/test-tf.R
+++ b/tests/testthat/test-tf.R
@@ -3,9 +3,9 @@ test_that("T and F are not okay", {
 
   bad1 <- system.file("bad1", package = "goodpractice")
   x <- gp(bad1, checks = "truefalse_not_tf")
-  expect_false(results(x)$result)
+  expect_false(results(x)$passed)
 
   x <- gp("bad2", checks = "truefalse_not_tf")
-  expect_true(results(x)$result)
+  expect_true(results(x)$passed)
 
 })


### PR DESCRIPTION
## Summary
- Rename the `result` column in `results()` output to `passed` for clarity
- Update roxygen docs and all test references

Closes #105

## Test plan
- [x] All existing tests updated and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)