### PR TITLE
Option A: Respect .lintr config when present

### DIFF
--- a/R/prep_lintr.R
+++ b/R/prep_lintr.R
@@ -24,10 +24,18 @@ linters_to_lint <- list(
 
 PREPS$lintr <- function(state, path = state$path, quiet) {
   path <- normalizePath(path)
-  suppressMessages(
-    state$lintr <- try(lint_package(path, linters = linters_to_lint),
-                       silent = TRUE)
-  )
+  lintr_config <- file.path(path, ".lintr")
+  if (file.exists(lintr_config)) {
+    cli::cli_inform("Using {.file .lintr} config from {.path {path}}")
+    suppressMessages(
+      state$lintr <- try(lint_package(path), silent = TRUE)
+    )
+  } else {
+    suppressMessages(
+      state$lintr <- try(lint_package(path, linters = linters_to_lint),
+                         silent = TRUE)
+    )
+  }
   if(inherits(state$lintr, "try-error")) {
     warning("Prep step for linter failed.")
   }


### PR DESCRIPTION
## Summary
- When a `.lintr` config file exists in the package, `lint_package()` is called without explicit linters, letting lintr's own config resolution take effect
- When no `.lintr` exists, goodpractice's hardcoded linter set is used as before
- Informs the user when a `.lintr` config is detected

### Tradeoffs
- **Pro:** Simple, predictable, fully respects whatever the user configured
- **Con:** gp's `lintr_*` checks silently pass when their corresponding linter isn't in the user's `.lintr` config (no findings = pass)

> [!WARNING]
> **Conflicts with #212.** These are two alternative approaches to #117. Only one should be merged — see #212 for the other option.

Ref #117

## Test plan
- [ ] Add test with example package containing `.lintr` config
- [ ] Verify existing lintr tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)