### PR TITLE
fix 'no_description_duplicate_deps' from #218

### DIFF
--- a/R/chk_description.R
+++ b/R/chk_description.R
@@ -162,7 +162,7 @@ CHECKS$no_description_duplicate_deps <- make_check(
     if(inherits(state$description, "try-error")) return(NA)
 
     deps <- state$description$get_deps()
-    deps <- deps[deps$package != "R", , drop = FALSE]
+    deps <- deps[deps$package != "R" & deps$type != "LinkingTo", , drop = FALSE]
     !anyDuplicated(deps$package)
   }
 )


### PR DESCRIPTION
 to ingore 'LinkingTo' field. Reprex of the problem:

``` r
library (goodpractice)
path <- srr::srr_stats_pkg_skeleton()
read.dcf (file.path (path, "DESCRIPTION"))
#>      Package Title                                          Version     
#> [1,] "demo"  "What the Package Does (One Line, Title Case)" "0.0.0.9000"
#>      Authors@R                                                                                                        
#> [1,] "person(given = \"First\",\nfamily = \"Last\",\nrole = c(\"aut\", \"cre\"),\nemail = \"first.last@example.com\")"
#>      Description                              Imports Suggests   LinkingTo
#> [1,] "What the package does (one paragraph)." "Rcpp"  "testthat" "Rcpp"   
#>      License Encoding
#> [1,] "GPL-3" "UTF-8" 
#>      Roxygen                                                                                
#> [1,] "list(markdown = TRUE, roclets = c (\"rd\", \"namespace\", \"srr::srr_stats_roclet\"))"
```
That `DESCRIPTION` has `Rcpp` in both "Suggests" and "LinkingTo", which it has to be! `LinkingTo` is one dependency field where duplicates have to be allowed. Current check does not allow that, and so generates this:
``` r
chk <- grep ("duplicate\\_deps", all_checks (), value = TRUE)
goodpractice::gp (path, checks = chk)
#> ℹ Preparing: description
#> ✔ Preparing: description [29ms]
#> 
#> ── GP demo ─────────────────────────────────────────────────────────────────────
#> 
#> It is good practice to
#> 
#>   ✖ not list the same package in multiple dependency fields (e.g. both Imports
#>     and Suggests). Each dependency should appear only once.
#> ────────────────────────────────────────────────────────────────────────────────
```

<sup>Created on 2026-03-19 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>