### PR TITLE
Handle empty coverage gracefully for data-only packages

### DIFF
--- a/R/chk_covr.R
+++ b/R/chk_covr.R
@@ -9,6 +9,9 @@ CHECKS$covr <- make_check(
 
   gp = function(state) {
     percent <- state$covr$pct_by_line
+    if (is.nan(percent)) {
+      return("write unit tests. No testable code was found in this package.")
+    }
     paste0(
       "write unit tests for all functions, and all package code in ",
       "general. ", trunc(percent), "% of code lines are covered by ",
@@ -19,7 +22,10 @@ CHECKS$covr <- make_check(
   check = function(state) {
     if(inherits(state$covr, "try-error"))
       return(list(status = NA, positions = list()))
-    
+
+    if (is.nan(state$covr$pct_by_line))
+      return(list(status = TRUE, positions = list()))
+
     zero <- state$covr$zero
     if (NROW(zero) == 0) return(list(status = TRUE, positions = list()))
     

--- a/tests/testthat/test-coverage.R
+++ b/tests/testthat/test-coverage.R
@@ -6,6 +6,28 @@ test_that("warning if prep step fails", {
                  "Prep step for.*covr.*failed")
 })
 
+test_that("covr check passes with NaN coverage (no testable code)", {
+  state <- list(covr = list(
+    coverage = structure(list(), class = "coverage"),
+    zero = data.frame(
+      filename = character(), functions = character(),
+      first_line = integer(), last_line = integer(),
+      first_column = integer(), last_column = integer(),
+      value = numeric(), stringsAsFactors = FALSE
+    ),
+    pct_by_line = NaN,
+    pct_by_expr = NaN
+  ))
+  result <- CHECKS$covr$check(state)
+  expect_true(result$status)
+})
+
+test_that("covr gp message handles NaN coverage", {
+  state <- list(covr = list(pct_by_line = NaN))
+  msg <- CHECKS$covr$gp(state)
+  expect_match(msg, "No testable code")
+})
+
 test_that("run_prep_step passes multiple ... args to fn", {
   state <- list()
   state <- run_prep_step(state, "test", function(a, b, c) {


### PR DESCRIPTION
## Summary

- When a package has no testable R code (e.g. data-only packages), `covr::percent_coverage()` returns `NaN`
- Previously this would show "NaN% of code lines are covered" in the output (and in older covr versions, crash with `aggregate.data.frame` error)
- Now the check passes cleanly with the message: "No testable code was found in this package"

Fixes #140.

## Test plan

- [ ] `covr` check passes when `pct_by_line` is `NaN`
- [ ] `gp` message says "No testable code" instead of "NaN%"
- [ ] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)