### PR TITLE
Fix roxygen2 check to ignore undocumented functions

### DIFF
--- a/R/chk_roxygen2.R
+++ b/R/chk_roxygen2.R
@@ -35,7 +35,12 @@ CHECKS$roxygen2_has_export_or_nord <- make_check(
   description = "Documented functions have @export or @noRd",
   tags = c("documentation", "roxygen2"),
   preps = "roxygen2",
-  gp = "Tag every documented function with either {.code @export} or {.code @noRd}.",
+  gp = paste(
+    "Tag every documented function with either {.code @export},",
+    "{.code @noRd}, or {.code @rdname}.",
+    "Functions without roxygen2 documentation are implicitly internal",
+    "and do not need tagging."
+  ),
 
   check = function(state) {
     if (inherits(state$roxygen2, "try-error")) return(roxygen2_na_result())
@@ -56,21 +61,6 @@ CHECKS$roxygen2_has_export_or_nord <- make_check(
       if (!has_tag && !in_ns) {
         problems[[length(problems) + 1]] <- make_block_position(block)
       }
-    }
-
-    for (i in seq_len(nrow(rox$function_defs))) {
-      fn <- rox$function_defs[i, ]
-      bare_name <- gsub("^`|`$", "", fn$name)
-      if (bare_name %in% documented_names) next
-      if (bare_name %in% rox$namespace_exports) next
-      if (bare_name %in% rox$namespace_s3methods) next
-      problems[[length(problems) + 1]] <- list(
-        filename = file.path("R", basename(fn$file)),
-        line_number = as.integer(fn$line),
-        column_number = NA_integer_,
-        ranges = list(),
-        line = fn$name
-      )
     }
 
     list(

--- a/tests/testthat/bad_roxygen/R/functions.R
+++ b/tests/testthat/bad_roxygen/R/functions.R
@@ -22,6 +22,12 @@ untagged_func <- function() {
   1
 }
 
+#' Documented but missing export/noRd tag
+#' @return A number.
+documented_no_tag <- function() {
+  42
+}
+
 #' Contradictory tags
 #' @export
 #' @keywords internal

--- a/tests/testthat/test-roxygen2.R
+++ b/tests/testthat/test-roxygen2.R
@@ -20,13 +20,35 @@ test_that("roxygen2 checks return NA for non-roxygen2 packages", {
 
 # -- roxygen2_has_export_or_nord ----------------------------------------------
 
-test_that("roxygen2_has_export_or_nord fails for untagged functions", {
+test_that("roxygen2_has_export_or_nord flags documented functions missing tags", {
   gp_res <- gp("bad_roxygen", checks = "roxygen2_has_export_or_nord")
   expect_false(results(gp_res)$passed)
 
   pos <- failed_positions(gp_res)$roxygen2_has_export_or_nord
   lines <- vapply(pos, `[[`, "", "line")
-  expect_match(lines, "untagged_func", all = FALSE)
+  expect_match(lines, "documented_no_tag", all = FALSE)
+})
+
+test_that("roxygen2_has_export_or_nord ignores undocumented functions", {
+  pkg <- withr::local_tempdir()
+  dir.create(file.path(pkg, "R"))
+  writeLines(c(
+    "Package: undoctest", "Title: Test", "Version: 1.0.0",
+    "Description: Test.", "License: MIT",
+    "Roxygen: list(markdown = TRUE)",
+    "RoxygenNote: 7.3.3"
+  ), file.path(pkg, "DESCRIPTION"))
+  writeLines("export(public_fn)", file.path(pkg, "NAMESPACE"))
+
+  writeLines(c(
+    "#' @export",
+    "public_fn <- function() 1",
+    "",
+    "internal_fn <- function() 2"
+  ), file.path(pkg, "R", "code.R"))
+
+  gp_res <- gp(pkg, checks = "roxygen2_has_export_or_nord")
+  expect_true(results(gp_res)$passed)
 })
 
 test_that("roxygen2_has_export_or_nord passes when all tagged", {


### PR DESCRIPTION
## Summary

- Remove the second loop in `roxygen2_has_export_or_nord` that flagged functions with no roxygen documentation at all
- Only flag functions that have roxygen blocks but lack `@export`/`@noRd`/`@rdname`
- Functions without roxygen docs are implicitly internal and don't need tagging

This addresses the feedback from #247 where the check forced agent-based tools to add purely cosmetic `#' @noRd` tags to every internal function.

## Test plan

- [x] Added test that documented-but-untagged functions are still flagged
- [x] Added test that undocumented functions are ignored
- [x] 640 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)