### PR TITLE
Use default_r_file_pattern() in ts_parse() for consistent file matching

### DIFF
--- a/R/treesitter.R
+++ b/R/treesitter.R
@@ -57,7 +57,7 @@ ts_parse <- function(path, exclude_path = character()) {
 
   lang <- treesitter.r::language()
   p <- treesitter::parser(lang)
-  rfiles <- list.files(rdir, pattern = "\\.[rR]$", full.names = TRUE)
+  rfiles <- list.files(rdir, pattern = default_r_file_pattern(), full.names = TRUE)
   rfiles <- filter_excluded_paths(rfiles, path, exclude_path)
 
   trees <- vector("list", length(rfiles))

--- a/tests/testthat/test-treesitter.R
+++ b/tests/testthat/test-treesitter.R
@@ -61,6 +61,16 @@ test_that("ts_file_functions skips non-identifier LHS", {
   expect_equal(fns[[1]]$name, "real_fn")
 })
 
+test_that("ts_parse finds functions in .S files", {
+  pkg <- withr::local_tempdir()
+  dir.create(file.path(pkg, "R"))
+  writeLines("myfun <- function(x) x + 1", file.path(pkg, "R", "legacy.S"))
+
+  ts <- ts_parse(pkg)
+  names <- vapply(ts$functions, `[[`, "", "name")
+  expect_true("myfun" %in% names)
+})
+
 test_that("ts_parse skips unreadable files", {
   pkg <- withr::local_tempdir()
   dir.create(file.path(pkg, "R"))


### PR DESCRIPTION
## Summary

- `ts_parse()` hardcoded `\\.[rR]$` while `default_r_file_pattern()` matches `\\.[RrSs]$`
- Treesitter-based checks silently skipped `.S`/`.s` files that expression-based checks would see
- Changed `ts_parse()` to use `default_r_file_pattern()` so both code paths see the same files

## Test plan

- [x] Added test verifying `ts_parse()` finds functions in `.S` files
- [x] All 33 treesitter tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)