### PR TITLE
Remove redundant wrappers and standardize prep functions

### DIFF
--- a/R/chk_rd.R
+++ b/R/chk_rd.R
@@ -1,8 +1,5 @@
 #' @include lists.R
 
-#' @noRd
-rd_na_result <- function() na_result()
-
 rd_find_topic <- function(rd_data, alias) {
   for (topic in rd_data) {
     if (alias %in% topic$aliases) return(topic)
@@ -25,10 +22,10 @@ rd_exported_aliases <- function(state) {
 }
 
 rd_check_field <- function(state, field, skip_internal = FALSE) {
-  if (inherits(state$rd, "try-error")) return(rd_na_result())
+  if (inherits(state$rd, "try-error")) return(na_result())
 
   rd_data <- state$rd
-  if (length(rd_data) == 0) return(rd_na_result())
+  if (length(rd_data) == 0) return(na_result())
 
   exports <- rd_exported_aliases(state)
   problems <- list()

--- a/R/chk_roxygen2.R
+++ b/R/chk_roxygen2.R
@@ -1,8 +1,5 @@
 #' @include lists.R
 
-#' @noRd
-roxygen2_na_result <- function() na_result()
-
 block_is_function <- function(block) {
   cl <- block$call
   if (is.null(cl) || !is.call(cl) || length(cl) < 3) return(FALSE)
@@ -42,7 +39,7 @@ CHECKS$roxygen2_has_export_or_nord <- make_check(
   ),
 
   check = function(state) {
-    if (inherits(state$roxygen2, "try-error")) return(roxygen2_na_result())
+    if (inherits(state$roxygen2, "try-error")) return(na_result())
     rox <- state$roxygen2
     problems <- list()
 
@@ -84,7 +81,7 @@ CHECKS$roxygen2_unknown_tags <- make_check(
   ),
 
   check = function(state) {
-    if (inherits(state$roxygen2, "try-error")) return(roxygen2_na_result())
+    if (inherits(state$roxygen2, "try-error")) return(na_result())
     rox <- state$roxygen2
     msgs <- if (is.null(rox$parse_messages)) character() else
       rox$parse_messages
@@ -131,7 +128,7 @@ CHECKS$roxygen2_valid_inherit <- make_check(
   ),
 
   check = function(state) {
-    if (inherits(state$roxygen2, "try-error")) return(roxygen2_na_result())
+    if (inherits(state$roxygen2, "try-error")) return(na_result())
     rox <- state$roxygen2
     pkg_fns <- rox$function_defs$name
     problems <- list()
@@ -189,7 +186,7 @@ CHECKS$roxygen2_duplicate_params <- make_check(
   ),
 
   check = function(state) {
-    if (inherits(state$roxygen2, "try-error")) return(roxygen2_na_result())
+    if (inherits(state$roxygen2, "try-error")) return(na_result())
 
     all_params <- unlist(
       lapply(state$roxygen2$blocks, extract_block_params),

--- a/R/chk_urlchecker.R
+++ b/R/chk_urlchecker.R
@@ -1,8 +1,5 @@
 #' @include lists.R
 
-#' @noRd
-urlchecker_na_result <- function() na_result()
-
 urlchecker_make_positions <- function(db) {
   lapply(seq_len(nrow(db)), function(i) {
     from <- db$From[[i]]
@@ -25,7 +22,7 @@ make_urlchecker_check <- function(description, gp, filter, tags = NULL) {
 
     check = function(state) {
       if (inherits(state$urlchecker, "try-error")) {
-        return(urlchecker_na_result())
+        return(na_result())
       }
 
       db <- state$urlchecker

--- a/R/prep_rd.R
+++ b/R/prep_rd.R
@@ -1,4 +1,4 @@
-#' @include lists.R
+#' @include lists.R prep_utils.R
 
 #' @noRd
 parse_rd_files <- function(mandir) {
@@ -45,12 +45,7 @@ parse_rd_files <- function(mandir) {
 }
 
 PREPS$rd <- function(state, path = state$path, quiet) {
-  mandir <- file.path(path, "man")
-
-  state$rd <- try(parse_rd_files(mandir), silent = quiet)
-
-  if (inherits(state$rd, "try-error")) {
-    cli::cli_warn("Prep step for {.val rd} failed.")
-  }
-  state
+  run_prep_step(state, "rd", function(path) {
+    parse_rd_files(file.path(path, "man"))
+  }, path = path, silent = quiet)
 }

--- a/R/prep_roxygen2.R
+++ b/R/prep_roxygen2.R
@@ -1,4 +1,4 @@
-#' @include lists.R
+#' @include lists.R prep_utils.R treesitter.R
 #' @importFrom roxygen2 parse_package
 
 #' @noRd
@@ -10,32 +10,15 @@ uses_roxygen2 <- function(path) {
 }
 
 find_function_defs <- function(path, exclude_path = character()) {
-  rfiles <- r_package_files(path, exclude_path)
-  empty <- data.frame(
-    name = character(), file = character(),
-    line = integer()
-  )
-
-  lang <- treesitter.r::language()
-  p <- treesitter::parser(lang)
-
-  defs <- list()
-  for (f in rfiles) {
-    if (!file.exists(f)) next
-    code <- paste(readLines(f, warn = FALSE), collapse = "\n")
-    tree <- treesitter::parser_parse(p, code)
-    root <- treesitter::tree_root_node(tree)
-
-    fns <- ts_file_functions(root, f)
-    for (fn in fns) {
-      defs[[length(defs) + 1]] <- data.frame(
-        name = fn$name, file = fn$file, line = fn$line
-      )
-    }
+  ts <- ts_parse(path, exclude_path)
+  if (length(ts$functions) == 0) {
+    return(data.frame(name = character(), file = character(), line = integer()))
   }
-
-  if (length(defs) == 0) return(empty)
-  do.call(rbind, defs)
+  data.frame(
+    name = vapply(ts$functions, `[[`, "", "name"),
+    file = vapply(ts$functions, `[[`, "", "file"),
+    line = vapply(ts$functions, function(fn) fn$line, numeric(1))
+  )
 }
 
 parse_roxygen2 <- function(path, exclude_path = character()) {
@@ -87,13 +70,7 @@ parse_roxygen2 <- function(path, exclude_path = character()) {
 }
 
 PREPS$roxygen2 <- function(state, path = state$path, quiet) {
-  state$roxygen2 <- try(
-    parse_roxygen2(path, state$exclude_path %||% character()),
-    silent = quiet
-  )
-
-  if (inherits(state$roxygen2, "try-error")) {
-    cli::cli_warn("Prep step for {.val roxygen2} failed.")
-  }
-  state
+  run_prep_step(state, "roxygen2", function(path) {
+    parse_roxygen2(path, state$exclude_path %||% character())
+  }, path = path, silent = quiet)
 }

--- a/tests/testthat/test-rd-checks.R
+++ b/tests/testthat/test-rd-checks.R
@@ -231,10 +231,14 @@ test_that("rd checks return NA when man/ directory is missing", {
 
 # -- prep error handling ------------------------------------------------------
 
-test_that("rd checks return NA when prep failed", {
+test_that("all rd checks return na_result when prep failed", {
   state <- list(rd = structure("error", class = "try-error"))
-  result <- CHECKS$rd_has_examples$check(state)
-  expect_true(is.na(result$status))
+
+  for (check_name in c("rd_has_examples", "rd_has_return")) {
+    result <- CHECKS[[check_name]]$check(state)
+    expect_true(is.na(result$status), label = paste(check_name, "status"))
+    expect_type(result$positions, "list")
+  }
 })
 
 # -- parse_rd_files -----------------------------------------------------------

--- a/tests/testthat/test-roxygen2.R
+++ b/tests/testthat/test-roxygen2.R
@@ -114,10 +114,19 @@ test_that("roxygen2_valid_inherit passes with valid references", {
 
 # -- prep error handling ------------------------------------------------------
 
-test_that("roxygen2 checks return NA on prep failure", {
+test_that("all roxygen2 checks return na_result on prep failure", {
   state <- list(roxygen2 = structure("error", class = "try-error"))
-  result <- CHECKS$roxygen2_unknown_tags$check(state)
-  expect_true(is.na(result$status))
+
+  for (check_name in c(
+    "roxygen2_has_export_or_nord",
+    "roxygen2_unknown_tags",
+    "roxygen2_valid_inherit",
+    "roxygen2_duplicate_params"
+  )) {
+    result <- CHECKS[[check_name]]$check(state)
+    expect_true(is.na(result$status), label = paste(check_name, "status"))
+    expect_type(result$positions, "list")
+  }
 })
 
 # -- block_is_function edge cases ---------------------------------------------

--- a/tests/testthat/test-urlchecker.R
+++ b/tests/testthat/test-urlchecker.R
@@ -23,8 +23,8 @@ add_from <- function(db, from) {
 
 # -- helpers -------------------------------------------------------------------
 
-test_that("urlchecker_na_result returns NA status with empty positions", {
-  res <- urlchecker_na_result()
+test_that("na_result returns NA status with empty positions", {
+  res <- na_result()
   expect_true(is.na(res$status))
   expect_length(res$positions, 0)
 })


### PR DESCRIPTION
## Summary
- Remove `roxygen2_na_result()`, `urlchecker_na_result()`, `rd_na_result()` trivial aliases — call `na_result()` directly
- Refactor `PREPS$roxygen2` and `PREPS$rd` to use `run_prep_step()` instead of manual try/warn boilerplate
- Simplify `find_function_defs()` to reuse `ts_parse()` instead of duplicating treesitter parser creation

Net -37 lines. No behavior change — just consistency and deduplication.

## Test plan
- [x] Existing tests pass
- [ ] Run `devtools::check()` to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>