### PR TITLE
Add check_position() constructor for position objects

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -82,7 +82,7 @@ CHECKS$<check_name> <- make_check(
     if (inherits(state$<prep_name>, "try-error"))
       return(na_result())
     # ... evaluate rule ...
-    list(status = <logical>, positions = <list of position objects>)
+    check_result(<logical>, <list of check_position() objects>)
   }
 )
 ```
@@ -101,30 +101,34 @@ Literal braces must be escaped as `{{` and `}}`.
 
 ### Check return values
 
-Either a bare logical (`TRUE`/`FALSE`/`NA`) or a list:
+Always use `check_result()` (defined in `R/utils.R`) to construct return values:
 
 ```r
-list(
-  status = TRUE,
-  positions = list()
-)
+check_result(TRUE)                        # passed, no positions
+check_result(FALSE, problems)             # failed with positions
+check_result(!grepl(...))                 # dynamic status, no positions
+check_result(TRUE, type = "info", ...)    # extra fields via ...
 ```
 
-Use `na_result()` for the common NA/skip case.
+`na_result()` is shorthand for `check_result()` (status = NA, positions = empty).
+
+Do **not** construct `list(status = ..., positions = ...)` manually.
 
 ### Position objects
 
+Always use `check_position()` (defined in `R/utils.R`) to construct positions:
+
 ```r
-list(
-  filename = "R/file.R",
-  line_number = 42L,
-  column_number = NA_integer_,
-  ranges = list(),
-  line = "the_offending_code_line"
-)
+check_position("R/file.R", 42L, line = "the_offending_line")
 ```
 
+Signature: `check_position(filename, line_number, column_number, ranges, line)`.
+Defaults: `line_number = NA_integer_`, `column_number = NA_integer_`,
+`ranges = list()`, `line = ""`.
+
 Filenames are relative to the package root. `line` is a short string shown to the user identifying the problem.
+
+Do **not** construct position lists manually.
 
 ### Factory functions
 

--- a/R/chk_avoided_packages.R
+++ b/R/chk_avoided_packages.R
@@ -56,13 +56,7 @@ CHECKS$no_obsolete_deps <- make_check(
 
     problems <- lapply(found, function(pkg) {
       dep_row <- deps[deps$package == pkg, ]
-      list(
-        filename = "DESCRIPTION",
-        line_number = NA_integer_,
-        column_number = NA_integer_,
-        ranges = list(),
-        line = paste0(dep_row$type[1], ": ", pkg)
-      )
+      check_position("DESCRIPTION", line = paste0(dep_row$type[1], ": ", pkg))
     })
 
     check_result(FALSE, problems)

--- a/R/chk_code_structure.R
+++ b/R/chk_code_structure.R
@@ -32,11 +32,9 @@ CHECKS$print_return_invisible <- make_check(
       caps <- treesitter::query_captures(invisible_q, body)
       if (length(caps$name) > 0) next
 
-      problems[[length(problems) + 1]] <- list(
-        filename = file.path("R", basename(fn$file)),
-        line_number = fn$line,
-        column_number = NA_integer_,
-        ranges = list(),
+      problems[[length(problems) + 1]] <- check_position(
+        file.path("R", basename(fn$file)),
+        fn$line,
         line = fn$name
       )
     }
@@ -102,11 +100,9 @@ CHECKS$on_exit_has_add <- make_check(
         if (ts_inside_nested_function(caps$node[[j]], body)) next
         call_node <- treesitter::node_parent(caps$node[[j]])
         if (on_exit_call_missing_add(call_node)) {
-          problems[[length(problems) + 1]] <- list(
-            filename = file.path("R", basename(fn$file)),
-            line_number = treesitter::node_start_point(call_node)$row + 1L,
-            column_number = NA_integer_,
-            ranges = list(),
+          problems[[length(problems) + 1]] <- check_position(
+            file.path("R", basename(fn$file)),
+            treesitter::node_start_point(call_node)$row + 1L,
             line = fn$name
           )
         }
@@ -153,13 +149,11 @@ CHECKS$complexity_function_length <- make_check(
     problems <- lapply(ts$functions, function(fn) {
       len <- ts_function_length(fn$fn_node)
       if (len <= limit) return(NULL)
-      list(
-        filename = file.path("R", basename(fn$file)),
-        line_number = fn$line,
-        column_number = NA_integer_,
-        ranges = list(),
+      check_position(
+        file.path("R", basename(fn$file)),
+        fn$line,
         line = paste0(fn$name, " (", len, " lines)")
-      )
+        )
     })
     problems <- Filter(Negate(is.null), problems)
 
@@ -268,13 +262,7 @@ CHECKS$complexity_unused_internal <- make_check(
 
     problems <- lapply(unused, function(name) {
       fn <- fn_lookup[[name]]
-      list(
-        filename = file.path("R", basename(fn$file)),
-        line_number = fn$line,
-        column_number = NA_integer_,
-        ranges = list(),
-        line = name
-      )
+      check_position(file.path("R", basename(fn$file)), fn$line, line = name)
     })
 
     check_result(FALSE, problems)
@@ -338,13 +326,11 @@ CHECKS$duplicate_function_bodies <- make_check(
     if (nrow(dupes) == 0) return(check_result(TRUE))
 
     problems <- lapply(seq_len(nrow(dupes)), function(i) {
-      list(
-        filename = file.path("R", basename(dupes$file[i])),
-        line_number = dupes$line[i],
-        column_number = NA_integer_,
-        ranges = list(),
+      check_position(
+        file.path("R", basename(dupes$file[i])),
+        dupes$line[i],
         line = dupes$name[i]
-      )
+        )
     })
 
     check_result(FALSE, problems)

--- a/R/chk_covr.R
+++ b/R/chk_covr.R
@@ -30,13 +30,7 @@ CHECKS$covr <- make_check(
     if (NROW(zero) == 0) return(check_result(TRUE))
     
     positions <- lapply(seq_len(NROW(zero)), function(i) {
-      list(
-        filename = zero$filename[i],
-        line_number = zero$line[i],
-        column_number = NA_integer_,
-        ranges = list(),
-        line = NA_character_
-      )
+      check_position(zero$filename[i], zero$line[i], line = NA_character_)
     })
     
     check_result(FALSE, positions)

--- a/R/chk_generic.R
+++ b/R/chk_generic.R
@@ -67,13 +67,7 @@ CHECKS$r_file_extension <- make_check(
       check_result(TRUE)
     } else {
       problems <- lapply(files, function(f) {
-        list(
-          filename = file.path("R", f),
-          line_number = NA_integer_,
-          column_number = NA_integer_,
-          ranges = list(),
-          line = f
-        )
+        check_position(file.path("R", f), line = f)
       })
       check_result(FALSE, problems)
     }

--- a/R/chk_rd.R
+++ b/R/chk_rd.R
@@ -36,11 +36,8 @@ rd_check_field <- function(state, field, skip_internal = FALSE) {
     if (skip_internal && isTRUE(topic$has_keyword_internal)) next
 
     if (!isTRUE(topic[[field]])) {
-      problems[[length(problems) + 1]] <- list(
-        filename = file.path("man", topic$file),
-        line_number = NA_integer_,
-        column_number = NA_integer_,
-        ranges = list(),
+      problems[[length(problems) + 1]] <- check_position(
+        file.path("man", topic$file),
         line = alias
       )
     }

--- a/R/chk_roxygen2.R
+++ b/R/chk_roxygen2.R
@@ -15,11 +15,9 @@ block_function_name <- function(block) {
 }
 
 make_block_position <- function(block) {
-  list(
-    filename = file.path("R", basename(block$file)),
-    line_number = as.integer(block$line),
-    column_number = NA_integer_,
-    ranges = list(),
+  check_position(
+    file.path("R", basename(block$file)),
+    as.integer(block$line),
     line = deparse(block$call, nlines = 1)
   )
 }
@@ -93,11 +91,9 @@ CHECKS$roxygen2_unknown_tags <- make_check(
       raw_file <- m[2]
       fname <- if (startsWith(raw_file, "R/")) raw_file else
         file.path("R", raw_file)
-      problems[[length(problems) + 1]] <- list(
-        filename = fname,
-        line_number = as.integer(m[3]),
-        column_number = NA_integer_,
-        ranges = list(),
+      problems[[length(problems) + 1]] <- check_position(
+        fname,
+        as.integer(m[3]),
         line = paste0("@", m[4])
       )
     }
@@ -205,11 +201,9 @@ CHECKS$roxygen2_duplicate_params <- make_check(
 
       for (i in idxs) {
         p <- all_params[[i]]
-        problems[[length(problems) + 1]] <- list(
-          filename = file.path("R", basename(p$file)),
-          line_number = as.integer(p$line),
-          column_number = NA_integer_,
-          ranges = list(),
+        problems[[length(problems) + 1]] <- check_position(
+          file.path("R", basename(p$file)),
+          as.integer(p$line),
           line = paste0("@param ", p$name)
         )
       }

--- a/R/chk_spelling.R
+++ b/R/chk_spelling.R
@@ -6,13 +6,7 @@ spelling_positions <- function(word, locations) {
     parts <- strsplit(loc, ":")[[1]]
     line_nums <- as.integer(strsplit(parts[2], ",")[[1]])
     lapply(line_nums, function(ln) {
-      list(
-        filename = parts[1],
-        line_number = ln,
-        column_number = NA_integer_,
-        ranges = list(),
-        line = word
-      )
+      check_position(parts[1], ln, line = word)
     })
   }), recursive = FALSE)
 }

--- a/R/chk_tidyverse.R
+++ b/R/chk_tidyverse.R
@@ -463,14 +463,8 @@ CHECKS$tidyverse_r_file_names <- make_check(
     bad_files <- r_files[grepl(bad_pattern, tools::file_path_sans_ext(r_files))]
 
     check_result(length(bad_files) == 0, lapply(bad_files, function(f) {
-        list(
-          filename = file.path("R", f),
-          line_number = NA_integer_,
-          column_number = NA_integer_,
-          ranges = list(),
-          line = f)
-      })
-    )
+        check_position(file.path("R", f), line = f)
+      }))
   }
 )
 
@@ -507,14 +501,11 @@ CHECKS$tidyverse_test_file_names <- make_check(
     untested <- untested[!grepl("^(zzz|RcppExports|reexport)", untested)]
 
     check_result(length(untested) == 0, lapply(untested, function(f) {
-        list(
-          filename = file.path("R", paste0(f, ".R")),
-          line_number = NA_integer_,
-          column_number = NA_integer_,
-          ranges = list(),
-          line = paste0("missing tests/testthat/test-", f, ".R"))
-      })
-    )
+        check_position(
+          file.path("R", paste0(f, ".R")),
+          line = paste0("missing tests/testthat/test-", f, ".R")
+          )
+      }))
   }
 )
 
@@ -546,11 +537,9 @@ CHECKS$tidyverse_no_missing <- make_check(
 
     for (fn in funcs) {
       if (ts_body_has_call(fn$fn_node, missing_q)) {
-        problems[[length(problems) + 1]] <- list(
-          filename = file.path("R", basename(fn$file)),
-          line_number = fn$line,
-          column_number = NA_integer_,
-          ranges = list(),
+        problems[[length(problems) + 1]] <- check_position(
+          file.path("R", basename(fn$file)),
+          fn$line,
           line = fn$name
         )
       }
@@ -620,11 +609,9 @@ CHECKS$tidyverse_export_order <- make_check(
       for (j in seq_len(last_export - 1)) {
         if (!is_exp[j]) {
           fn <- file_funcs[[j]]
-          problems[[length(problems) + 1]] <- list(
-            filename = file.path("R", basename(fn$file)),
-            line_number = fn$line,
-            column_number = NA_integer_,
-            ranges = list(),
+          problems[[length(problems) + 1]] <- check_position(
+            file.path("R", basename(fn$file)),
+            fn$line,
             line = fn$name
           )
         }

--- a/R/chk_urlchecker.R
+++ b/R/chk_urlchecker.R
@@ -3,13 +3,10 @@
 urlchecker_make_positions <- function(db) {
   lapply(seq_len(nrow(db)), function(i) {
     from <- db$From[[i]]
-    list(
-      filename = if (length(from) > 0) from[[1]] else "unknown",
-      line_number = NA_integer_,
-      column_number = NA_integer_,
-      ranges = list(),
+    check_position(
+      if (length(from) > 0) from[[1]] else "unknown",
       line = db$URL[i]
-    )
+      )
   })
 }
 

--- a/R/chk_vignette.R
+++ b/R/chk_vignette.R
@@ -133,11 +133,10 @@ check_vignette_calls <- function(state, fn_name, nested_fn = NULL) {
       ln <- fn_rows$line1[i]
       line_text <- if (ln <= length(orig_lines)) orig_lines[ln] else ""
 
-      problems[[length(problems) + 1]] <- list(
-        filename = file.path("vignettes", basename(f)),
-        line_number = ln,
-        column_number = fn_rows$col1[i],
-        ranges = list(),
+      problems[[length(problems) + 1]] <- check_position(
+        file.path("vignettes", basename(f)),
+        ln,
+        fn_rows$col1[i],
         line = trimws(line_text)
       )
     }

--- a/R/utils.R
+++ b/R/utils.R
@@ -15,6 +15,20 @@ na_result <- function() {
   check_result()
 }
 
+#' Construct a source position object
+#'
+#' General constructor for the position objects returned by check
+#' functions. Each position identifies a location in the source code
+#' where a check found an issue. Use this instead of building
+#' `list(filename, line_number, ...)` by hand.
+#'
+#' @param filename Path relative to the package root, e.g. `"R/foo.R"`.
+#' @param line_number Line number (1-based), or `NA_integer_` if unknown.
+#' @param column_number Column number, or `NA_integer_` if unknown.
+#' @param ranges List of start/end pairs for multi-line issues.
+#' @param line Short display string identifying the problem to the user.
+#' @return A named list with the five position fields.
+#' @keywords internal
 #' @noRd
 check_position <- function(filename, line_number = NA_integer_,
                            column_number = NA_integer_,

--- a/R/utils.R
+++ b/R/utils.R
@@ -15,6 +15,19 @@ na_result <- function() {
   check_result()
 }
 
+#' @noRd
+check_position <- function(filename, line_number = NA_integer_,
+                           column_number = NA_integer_,
+                           ranges = list(), line = "") {
+  list(
+    filename = filename,
+    line_number = line_number,
+    column_number = column_number,
+    ranges = ranges,
+    line = line
+  )
+}
+
 #' Default pattern for R files
 #' @return Regular expression.
 #' @keywords internal


### PR DESCRIPTION
## Summary
- Introduces `check_position(filename, line_number, column_number, ranges, line)` with sensible defaults (`NA_integer_`, `list()`, `""`)
- Replaces 19 inline `list()` position constructions across 10 check files
- `make_block_position()` in `chk_roxygen2.R` now delegates to `check_position()`
- Net -51 lines

Companion to the `check_result()` constructor merged in #265. Together they formalize the two core data structures that checks produce.

## Test plan
- [x] All 732 tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>