### PR TITLE
Standardize prep error handling via run_prep_step()

### DIFF
--- a/R/prep_revdep.R
+++ b/R/prep_revdep.R
@@ -17,12 +17,7 @@ PREPS$revdep <- function(state, path = state$path, quiet) {
     repos <- "https://cloud.r-project.org"
   }
 
-  state$revdep <- try(
-    utils::available.packages(repos = repos),
-    silent = quiet
-  )
-  if (inherits(state$revdep, "try-error")) {
-    cli::cli_warn("Prep step for {.val revdep} failed.")
-  }
-  state
+  run_prep_step(state, "revdep", function(repos) {
+    utils::available.packages(repos = repos)
+  }, repos = repos, silent = quiet)
 }

--- a/R/prep_spelling.R
+++ b/R/prep_spelling.R
@@ -12,12 +12,7 @@ PREPS$spelling <- function(state, path = state$path, quiet) {
     }
     return(state)
   }
-  state$spelling <- try(
-    suppressMessages(spell_check_package(path)),
-    silent = quiet
-  )
-  if (inherits(state$spelling, "try-error")) {
-    cli::cli_warn("Prep step for {.val spelling} failed.")
-  }
-  state
+  run_prep_step(state, "spelling", function(path) {
+    suppressMessages(spell_check_package(path))
+  }, path = path, silent = quiet)
 }

--- a/R/prep_urlchecker.R
+++ b/R/prep_urlchecker.R
@@ -13,9 +13,7 @@ PREPS$urlchecker <- function(state, path = state$path, quiet) {
     return(state)
   }
 
-  state$urlchecker <- try(run_url_check(path, quiet), silent = quiet)
-  if (inherits(state$urlchecker, "try-error")) {
-    cli::cli_warn("Prep step for {.val urlchecker} failed.")
-  }
-  state
+  run_prep_step(state, "urlchecker", function(path, quiet) {
+    run_url_check(path, quiet)
+  }, path = path, quiet = quiet, silent = quiet)
 }

--- a/R/prep_vignette.R
+++ b/R/prep_vignette.R
@@ -1,19 +1,21 @@
 
 #' @include lists.R
 #' @include chk_vignette.R
+#' @include prep_utils.R
 
 PREPS$vignette <- function(state, path = state$path, quiet) {
-  vfiles <- vignette_files(path)
-  pd_list <- list()
-  for (f in vfiles) {
-    pd <- vignette_parse_data(f)
-    if (!is.null(pd)) {
-      pd_list[[f]] <- list(
-        parse_data = pd,
-        lines = readLines(f, warn = FALSE)
-      )
+  run_prep_step(state, "vignette", function(path) {
+    vfiles <- vignette_files(path)
+    pd_list <- list()
+    for (f in vfiles) {
+      pd <- vignette_parse_data(f)
+      if (!is.null(pd)) {
+        pd_list[[f]] <- list(
+          parse_data = pd,
+          lines = readLines(f, warn = FALSE)
+        )
+      }
     }
-  }
-  state$vignette <- pd_list
-  state
+    pd_list
+  }, path = path, silent = quiet)
 }


### PR DESCRIPTION
## Summary
- Refactored `prep_spelling`, `prep_revdep`, and `prep_urlchecker` to use the centralized `run_prep_step()` instead of duplicating `try()` + `cli::cli_warn()` boilerplate
- Wrapped `prep_vignette` in `run_prep_step()` — it previously had no error handling at all, meaning a single unreadable vignette file could crash the entire `gp()` run
- Early-return logic for legitimate skip conditions (missing WORDLIST, offline) is preserved

## Test plan
- [x] `devtools::test()` passes all 733 tests
- [x] `devtools::document()` runs cleanly (Collate updated for prep_vignette.R)
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Review feedback assisted by the [critical-code-reviewer skill](https://github.com/posit-dev/skills/blob/main/posit-dev/critical-code-reviewer/SKILL.md).