### PR TITLE
Fix check return type consistency

### DIFF
--- a/R/chk_revdep.R
+++ b/R/chk_revdep.R
@@ -10,7 +10,7 @@ query_reverse_deps <- function(pkg_name, db) {
 revdep_gp_message <- function(revdeps) {
   n <- length(revdeps)
   dep_list <- paste(utils::head(revdeps, 10), collapse = ", ")
-  suffix <- ifelse(n > 10, paste0(", ... and ", n - 10L, " more"), "")
+  suffix <- if (n > 10) paste0(", ... and ", n - 10L, " more") else ""
   paste0(
     "run revdepcheck::revdep_check() before CRAN submission. ",
     "This package has ", n, " reverse ",

--- a/R/chk_tidyverse.R
+++ b/R/chk_tidyverse.R
@@ -456,7 +456,7 @@ CHECKS$tidyverse_r_file_names <- make_check(
 
   check = function(state) {
     r_dir <- file.path(state$path, "R")
-    if (!dir.exists(r_dir)) return(TRUE)
+    if (!dir.exists(r_dir)) return(check_result(TRUE))
 
     r_files <- basename(list.files(r_dir, pattern = "\\.[Rr]$"))
     bad_pattern <- "[A-Z]|[- ]"
@@ -487,7 +487,7 @@ CHECKS$tidyverse_test_file_names <- make_check(
     r_files <- tools::file_path_sans_ext(
       basename(list.files(r_dir, pattern = "\\.[Rr]$"))
     )
-    if (length(r_files) == 0) return(TRUE)
+    if (length(r_files) == 0) return(check_result(TRUE))
 
     test_dir <- file.path(state$path, "tests", "testthat")
     test_files <- if (dir.exists(test_dir)) {


### PR DESCRIPTION
## Summary
- Changed two bare `return(TRUE)` to `return(check_result(TRUE))` in `tidyverse_r_file_names` and `tidyverse_test_file_names` checks, matching the standardized return type from #265
- Replaced scalar `ifelse()` with `if`/`else` in `revdep_gp_message()` — the package's own `lintr_redundant_ifelse_linter` warns against this pattern

## Test plan
- [x] `devtools::test()` passes all 733 tests
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Review feedback assisted by the [critical-code-reviewer skill](https://github.com/posit-dev/skills/blob/main/posit-dev/critical-code-reviewer/SKILL.md).