### PR TITLE
Fix review issues: NULL guard, indentation, and test assertion

### DIFF
--- a/R/chk_code_structure.R
+++ b/R/chk_code_structure.R
@@ -153,7 +153,7 @@ CHECKS$complexity_function_length <- make_check(
         file.path("R", basename(fn$file)),
         fn$line,
         line = paste0(fn$name, " (", len, " lines)")
-        )
+      )
     })
     problems <- Filter(Negate(is.null), problems)
 
@@ -324,7 +324,7 @@ CHECKS$duplicate_function_bodies <- make_check(
         file.path("R", basename(dupes$file[i])),
         dupes$line[i],
         line = dupes$name[i]
-        )
+      )
     })
 
     check_result(FALSE, problems)

--- a/R/chk_urlchecker.R
+++ b/R/chk_urlchecker.R
@@ -6,7 +6,7 @@ urlchecker_make_positions <- function(db) {
     check_position(
       if (length(from) > 0) from[[1]] else "unknown",
       line = db$URL[i]
-      )
+    )
   })
 }
 

--- a/R/prep_lintr.R
+++ b/R/prep_lintr.R
@@ -2,79 +2,79 @@
 linters_to_lint <- function() {
   list(
     # -- existing checks --
-  assignment_linter = lintr::assignment_linter(),
-  line_length_linter = lintr::line_length_linter(80),
-  package_hooks_linter = lintr::package_hooks_linter(),
-  semicolon_linter = lintr::semicolon_linter(allow_compound = TRUE),
-  attach_detach_linter = lintr::undesirable_function_linter(
-    fun = lintr::default_undesirable_functions[c("attach", "detach")]
-  ),
-  setwd_linter = lintr::undesirable_function_linter(
-    fun = lintr::default_undesirable_functions["setwd"]
-  ),
-  sapply_linter = lintr::undesirable_function_linter(
-    fun = lintr::default_undesirable_functions["sapply"]
-  ),
-  library_require_linter = lintr::undesirable_function_linter(
-    fun = lintr::default_undesirable_functions[c("library", "require")]
-  ),
-  seq_linter = lintr::seq_linter(),
+    assignment_linter = lintr::assignment_linter(),
+    line_length_linter = lintr::line_length_linter(80),
+    package_hooks_linter = lintr::package_hooks_linter(),
+    semicolon_linter = lintr::semicolon_linter(allow_compound = TRUE),
+    attach_detach_linter = lintr::undesirable_function_linter(
+      fun = lintr::default_undesirable_functions[c("attach", "detach")]
+    ),
+    setwd_linter = lintr::undesirable_function_linter(
+      fun = lintr::default_undesirable_functions["setwd"]
+    ),
+    sapply_linter = lintr::undesirable_function_linter(
+      fun = lintr::default_undesirable_functions["sapply"]
+    ),
+    library_require_linter = lintr::undesirable_function_linter(
+      fun = lintr::default_undesirable_functions[c("library", "require")]
+    ),
+    seq_linter = lintr::seq_linter(),
 
     # -- correctness / performance --
-  any_duplicated_linter = lintr::any_duplicated_linter(),
-  any_is_na_linter = lintr::any_is_na_linter(),
-  class_equals_linter = lintr::class_equals_linter(),
-  condition_message_linter = lintr::condition_message_linter(),
-  duplicate_argument_linter = lintr::duplicate_argument_linter(),
-  equals_na_linter = lintr::equals_na_linter(),
-  fixed_regex_linter = lintr::fixed_regex_linter(),
-  for_loop_index_linter = lintr::for_loop_index_linter(),
-  length_test_linter = lintr::length_test_linter(),
-  matrix_apply_linter = lintr::matrix_apply_linter(),
-  missing_argument_linter = lintr::missing_argument_linter(),
-  nrow_subset_linter = lintr::nrow_subset_linter(),
-  redundant_equals_linter = lintr::redundant_equals_linter(),
-  redundant_ifelse_linter = lintr::redundant_ifelse_linter(),
-  regex_subset_linter = lintr::regex_subset_linter(),
-  sort_linter = lintr::sort_linter(),
-  system_file_linter = lintr::system_file_linter(),
-  terminal_close_linter = lintr::terminal_close_linter(),
-  which_grepl_linter = lintr::which_grepl_linter(),
+    any_duplicated_linter = lintr::any_duplicated_linter(),
+    any_is_na_linter = lintr::any_is_na_linter(),
+    class_equals_linter = lintr::class_equals_linter(),
+    condition_message_linter = lintr::condition_message_linter(),
+    duplicate_argument_linter = lintr::duplicate_argument_linter(),
+    equals_na_linter = lintr::equals_na_linter(),
+    fixed_regex_linter = lintr::fixed_regex_linter(),
+    for_loop_index_linter = lintr::for_loop_index_linter(),
+    length_test_linter = lintr::length_test_linter(),
+    matrix_apply_linter = lintr::matrix_apply_linter(),
+    missing_argument_linter = lintr::missing_argument_linter(),
+    nrow_subset_linter = lintr::nrow_subset_linter(),
+    redundant_equals_linter = lintr::redundant_equals_linter(),
+    redundant_ifelse_linter = lintr::redundant_ifelse_linter(),
+    regex_subset_linter = lintr::regex_subset_linter(),
+    sort_linter = lintr::sort_linter(),
+    system_file_linter = lintr::system_file_linter(),
+    terminal_close_linter = lintr::terminal_close_linter(),
+    which_grepl_linter = lintr::which_grepl_linter(),
 
     # -- readability / idiom --
-  boolean_arithmetic_linter = lintr::boolean_arithmetic_linter(),
-  comparison_negation_linter = lintr::comparison_negation_linter(),
-  consecutive_assertion_linter = lintr::consecutive_assertion_linter(),
-  if_not_else_linter = lintr::if_not_else_linter(),
-  ifelse_censor_linter = lintr::ifelse_censor_linter(),
-  implicit_assignment_linter = lintr::implicit_assignment_linter(),
-  inner_combine_linter = lintr::inner_combine_linter(),
-  length_levels_linter = lintr::length_levels_linter(),
-  literal_coercion_linter = lintr::literal_coercion_linter(),
-  nested_ifelse_linter = lintr::nested_ifelse_linter(),
-  nested_pipe_linter = lintr::nested_pipe_linter(),
-  numeric_leading_zero_linter = lintr::numeric_leading_zero_linter(),
-  outer_negation_linter = lintr::outer_negation_linter(),
-  paste_linter = lintr::paste_linter(),
-  scalar_in_linter = lintr::scalar_in_linter(),
-  strings_as_factors_linter = lintr::strings_as_factors_linter(),
-  undesirable_operator_linter = lintr::undesirable_operator_linter(),
-  unnecessary_concatenation_linter = lintr::unnecessary_concatenation_linter(),
-  unnecessary_lambda_linter = lintr::unnecessary_lambda_linter(),
-  unreachable_code_linter = lintr::unreachable_code_linter(),
+    boolean_arithmetic_linter = lintr::boolean_arithmetic_linter(),
+    comparison_negation_linter = lintr::comparison_negation_linter(),
+    consecutive_assertion_linter = lintr::consecutive_assertion_linter(),
+    if_not_else_linter = lintr::if_not_else_linter(),
+    ifelse_censor_linter = lintr::ifelse_censor_linter(),
+    implicit_assignment_linter = lintr::implicit_assignment_linter(),
+    inner_combine_linter = lintr::inner_combine_linter(),
+    length_levels_linter = lintr::length_levels_linter(),
+    literal_coercion_linter = lintr::literal_coercion_linter(),
+    nested_ifelse_linter = lintr::nested_ifelse_linter(),
+    nested_pipe_linter = lintr::nested_pipe_linter(),
+    numeric_leading_zero_linter = lintr::numeric_leading_zero_linter(),
+    outer_negation_linter = lintr::outer_negation_linter(),
+    paste_linter = lintr::paste_linter(),
+    scalar_in_linter = lintr::scalar_in_linter(),
+    strings_as_factors_linter = lintr::strings_as_factors_linter(),
+    undesirable_operator_linter = lintr::undesirable_operator_linter(),
+    unnecessary_concatenation_linter = lintr::unnecessary_concatenation_linter(),
+    unnecessary_lambda_linter = lintr::unnecessary_lambda_linter(),
+    unreachable_code_linter = lintr::unreachable_code_linter(),
 
     # -- testthat expectations --
-  conjunct_test_linter = lintr::conjunct_test_linter(),
-  expect_comparison_linter = lintr::expect_comparison_linter(),
-  expect_identical_linter = lintr::expect_identical_linter(),
-  expect_length_linter = lintr::expect_length_linter(),
-  expect_named_linter = lintr::expect_named_linter(),
-  expect_not_linter = lintr::expect_not_linter(),
-  expect_null_linter = lintr::expect_null_linter(),
-  expect_s3_class_linter = lintr::expect_s3_class_linter(),
-  expect_s4_class_linter = lintr::expect_s4_class_linter(),
-  expect_true_false_linter = lintr::expect_true_false_linter(),
-  expect_type_linter = lintr::expect_type_linter()
+    conjunct_test_linter = lintr::conjunct_test_linter(),
+    expect_comparison_linter = lintr::expect_comparison_linter(),
+    expect_identical_linter = lintr::expect_identical_linter(),
+    expect_length_linter = lintr::expect_length_linter(),
+    expect_named_linter = lintr::expect_named_linter(),
+    expect_not_linter = lintr::expect_not_linter(),
+    expect_null_linter = lintr::expect_null_linter(),
+    expect_s3_class_linter = lintr::expect_s3_class_linter(),
+    expect_s4_class_linter = lintr::expect_s4_class_linter(),
+    expect_true_false_linter = lintr::expect_true_false_linter(),
+    expect_type_linter = lintr::expect_type_linter()
   )
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -44,7 +44,7 @@ check_position <- function(filename, line_number = NA_integer_,
 
 ns_s3_method_names <- function(ns) {
   s3m <- ns$S3methods
-  if (nrow(s3m) > 0) paste0(s3m[, 1], ".", s3m[, 2]) else character()
+  if (is.null(s3m) || nrow(s3m) == 0) character() else paste0(s3m[, 1], ".", s3m[, 2])
 }
 
 #' Default pattern for R files

--- a/tests/testthat/test-gp.R
+++ b/tests/testthat/test-gp.R
@@ -193,4 +193,8 @@ test_that("parallel merge warns on conflicting fields", {
     run_preps(state, c("a", "b"), preps, quiet = TRUE),
     "Parallel prep conflict"
   )
+  result <- suppressWarnings(
+    run_preps(state, c("a", "b"), preps, quiet = TRUE)
+  )
+  expect_equal(result$my_field, "from_a")
 })

--- a/tests/testthat/test-gp.R
+++ b/tests/testthat/test-gp.R
@@ -190,11 +190,8 @@ test_that("parallel merge warns on conflicting fields", {
 
   preps <- list(a = prep_a, b = prep_b)
   expect_warning(
-    run_preps(state, c("a", "b"), preps, quiet = TRUE),
+    result <- run_preps(state, c("a", "b"), preps, quiet = TRUE),
     "Parallel prep conflict"
-  )
-  result <- suppressWarnings(
-    run_preps(state, c("a", "b"), preps, quiet = TRUE)
   )
   expect_equal(result$my_field, "from_a")
 })


### PR DESCRIPTION
## Summary

Fixes from a critical code review of the recent refactoring PRs (#265–#271):

- **NULL guard in `ns_s3_method_names()`**: `nrow(s3m)` crashes when `ns$S3methods` is `NULL` (as opposed to a 0-row matrix). Added `is.null(s3m)` check since this is now a shared utility called from 4 sites.
- **`linters_to_lint()` indentation**: When the bare `list()` was wrapped in a function body (#269), the inner entries kept their original 2-space indent instead of gaining the extra 2 spaces. Now consistent.
- **Closing paren alignment**: Fixed misaligned `)` in `check_position()` calls in `chk_code_structure.R` and `chk_urlchecker.R`.
- **Stronger merge-conflict test**: The parallel prep conflict test now asserts that the first writer's value survives (`expect_equal(result$my_field, "from_a")`), locking down first-writer-wins behavior.

## Test plan

- [x] `devtools::document()` — clean
- [x] `devtools::test()` — 0 failures, 734 passes
- [x] `devtools::check()` — 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)