### PR TITLE
Fix false positives in unused internal functions check

### DIFF
--- a/R/chk_code_structure.R
+++ b/R/chk_code_structure.R
@@ -200,11 +200,15 @@ ts_rhs_identifiers <- function(language, entry) {
 
 ts_body_identifiers <- function(language, entry) {
   id_q <- treesitter::query(language, "(identifier) @id")
-  fns <- ts_file_functions(entry$root, "")
-  unlist(lapply(fns, function(fn) {
-    body <- treesitter::node_child_by_field_name(
-      fn$fn_node, "body"
-    )
+  fn_q <- treesitter::query(language, "(function_definition) @fn")
+  infix_q <- treesitter::query(language, "(binary_operator operator: _ @op)")
+
+  fn_caps <- treesitter::query_captures(fn_q, entry$root)
+  fn_nodes <- fn_caps$node[fn_caps$name == "fn"]
+  if (length(fn_nodes) == 0) return(character())
+
+  ids <- unlist(lapply(fn_nodes, function(fn_node) {
+    body <- treesitter::node_child_by_field_name(fn_node, "body")
     if (is.null(body)) return(NULL)
     caps <- treesitter::query_captures(id_q, body)
     vapply(
@@ -212,6 +216,13 @@ ts_body_identifiers <- function(language, entry) {
       treesitter::node_text, character(1)
     )
   }))
+
+  infix_caps <- treesitter::query_captures(infix_q, entry$root)
+  op_nodes <- infix_caps$node[infix_caps$name == "op"]
+  is_special <- vapply(op_nodes, treesitter::node_type, character(1)) == "special"
+  infix_names <- vapply(op_nodes[is_special], treesitter::node_text, character(1))
+
+  c(ids, infix_names)
 }
 
 CHECKS$complexity_unused_internal <- make_check(

--- a/R/utils.R
+++ b/R/utils.R
@@ -44,7 +44,8 @@ check_position <- function(filename, line_number = NA_integer_,
 
 ns_s3_method_names <- function(ns) {
   s3m <- ns$S3methods
-  if (nrow(s3m) > 0) paste0(s3m[, 1], ".", s3m[, 2]) else character()
+  if (is.null(s3m) || nrow(s3m) == 0) return(character())
+  paste0(s3m[, 1], ".", s3m[, 2])
 }
 
 #' Default pattern for R files


### PR DESCRIPTION
## Summary
- `ts_body_identifiers()` now queries for ALL `function_definition` nodes in each file, not just top-level named functions via `ts_file_functions()`. This catches functions called from within `CHECKS$`/`PREPS$` lambda bodies (e.g. `lapply(x, helper)` inside a check function).
- Detects infix operator references (`%||%` etc.) via `binary_operator` nodes with `special` type.
- Adds NULL guard to `ns_s3_method_names()` for packages where `ns$S3methods` is NULL.

## Test plan
- [x] `devtools::test()` passes (733 tests)
- [x] Run `gp(".")` on goodpractice itself — `spelling_positions`, `extract_block_params`, `%||%`, `trim_ws` should no longer be flagged as unused

🤖 Generated with [Claude Code](https://claude.com/claude-code)