### PR TITLE
Filter non-function objects from cyclocomp results

### DIFF
--- a/R/prep_cyclocomp.R
+++ b/R/prep_cyclocomp.R
@@ -4,6 +4,20 @@
 
 PREPS$cyclocomp <- function(state, path = state$path, quiet) {
   run_prep_step(state, "cyclocomp", function(path) {
-    cyclocomp_package_dir(path)
+    df <- cyclocomp_package_dir(path)
+    r_files <- list.files(
+      file.path(path, "R"),
+      pattern = "\\.[rR]$",
+      full.names = TRUE
+    )
+    top_level_fns <- unlist(lapply(r_files, function(f) {
+      lines <- readLines(f, warn = FALSE)
+      pat <- "^(?:`([^`]+)`|([a-zA-Z._][a-zA-Z0-9._]*))\\s*(<-|=)\\s*function\\s*\\("
+      m <- regmatches(lines, regexec(pat, lines, perl = TRUE))
+      vapply(m[lengths(m) > 0], function(x) {
+        if (nzchar(x[2])) x[2] else x[3]
+      }, "")
+    }))
+    df[df$name %in% top_level_fns, , drop = FALSE]
   }, path = path, silent = quiet)
 }


### PR DESCRIPTION
## Summary
- `cyclocomp_package_dir()` aggregates complexity of nested lambdas in list objects like `CHECKS` (652) and `PREPS` (18), reporting them as single high-complexity "functions"
- Filter the cyclocomp data frame to only include names matching top-level `name <- function(` definitions in R/ source files
- Handles both bare names and backtick-quoted names (e.g. `` `%||%` ``)

## Test plan
- [x] `devtools::test()` passes (733 tests)
- [x] Run `gp(".")` on goodpractice itself — `CHECKS (652)` should no longer appear in cyclocomp findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)