### PR TITLE
Dogfood cleanup: lint fixes and modern test expectations

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -13,4 +13,5 @@
 ^AGENT\.md$
 ^\.git$
 ^\.Rprofile$
+^\.claude$
 ^makefile$

--- a/R/api.R
+++ b/R/api.R
@@ -83,7 +83,7 @@ failed_positions <- function(gp) {
 }
 
 get_position <- function(chk) {
-  if (! "positions" %in% names(chk)) NULL else chk$positions
+  if ("positions" %in% names(chk)) chk$positions else NULL
 }
 
 #' Export failed checks to JSON

--- a/R/prep_covr.R
+++ b/R/prep_covr.R
@@ -9,9 +9,9 @@ PREPS$covr <- function(state, path = state$path, quiet) {
   }, path = path, quiet = quiet, silent = quiet)
 
   if (!inherits(state$covr, "try-error")) {
-    with_options(
+    state$covr$zero <- with_options(
       list(covr.rstudio_source_markers = FALSE),
-      state$covr$zero <- zero_coverage(state$covr$coverage)
+      zero_coverage(state$covr$coverage)
     )
     state$covr$pct_by_line <- percent_coverage(state$covr$coverage, by = "line")
     state$covr$pct_by_expr <- percent_coverage(

--- a/R/prep_roxygen2.R
+++ b/R/prep_roxygen2.R
@@ -31,7 +31,7 @@ parse_roxygen2 <- function(path, exclude_path = character()) {
   parse_messages <- character()
   blocks <- withCallingHandlers(
     {
-      bl <- lapply(rfiles, function(f) roxygen2::parse_file(f))
+      bl <- lapply(rfiles, roxygen2::parse_file)
       do.call(c, bl)
     },
     message = function(m) {

--- a/R/treesitter.R
+++ b/R/treesitter.R
@@ -57,7 +57,9 @@ ts_parse <- function(path, exclude_path = character()) {
 
   lang <- treesitter.r::language()
   p <- treesitter::parser(lang)
-  rfiles <- list.files(rdir, pattern = default_r_file_pattern(), full.names = TRUE)
+  rfiles <- list.files(
+    rdir, pattern = default_r_file_pattern(), full.names = TRUE
+  )
   rfiles <- filter_excluded_paths(rfiles, path, exclude_path)
 
   trees <- vector("list", length(rfiles))

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -6,7 +6,7 @@ x <- suppressWarnings(
 )
 
 test_that("checks", {
-  expect_equal(checks(x), c("covr", "description_bugreports"))
+  expect_identical(checks(x), c("covr", "description_bugreports"))
 })
 
 test_that("results", {
@@ -15,7 +15,7 @@ test_that("results", {
     passed = c(NA, FALSE),
     stringsAsFactors = FALSE
   )
-  expect_equal(results(x), res)
+  expect_identical(results(x), res)
 })
 
 test_that("failed_checks returns names of failed checks", {
@@ -32,14 +32,14 @@ test_that("failed_positions returns positions for failed checks", {
 
 test_that("failed_positions returns empty list when check has no positions", {
   fp <- failed_positions(x)
-  expect_equal(fp$description_bugreports, list())
+  expect_identical(fp$description_bugreports, list())
 })
 
 test_that("failed_positions returns positions when check has them", {
   y <- gp(bad1, checks = "r_file_extension")
   fp <- failed_positions(y)
   expect_type(fp$r_file_extension, "list")
-  expect_true(length(fp$r_file_extension) > 0)
+  expect_gt(length(fp$r_file_extension), 0)
 })
 
 test_that("export_json writes valid JSON", {
@@ -47,7 +47,7 @@ test_that("export_json writes valid JSON", {
   export_json(x, file = tmp)
   expect_true(file.exists(tmp))
   obj <- jsonlite::fromJSON(tmp)
-  expect_equal(obj$package, "badpackage")
+  expect_identical(obj$package, "badpackage")
   expect_true("failures" %in% names(obj))
   expect_true("gp_version" %in% names(obj))
 })
@@ -59,5 +59,5 @@ test_that("export_json pretty-prints when requested", {
     readLines(tmp),
     "incomplete final line"
   )
-  expect_true(length(content) > 1)
+  expect_gt(length(content), 1)
 })

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -42,6 +42,11 @@ test_that("failed_positions returns positions when check has them", {
   expect_gt(length(fp$r_file_extension), 0)
 })
 
+test_that("get_position returns NULL when check has no positions", {
+  chk <- list(passed = FALSE)
+  expect_null(goodpractice:::get_position(chk))
+})
+
 test_that("export_json writes valid JSON", {
   tmp <- withr::local_tempfile(fileext = ".json")
   export_json(x, file = tmp)

--- a/tests/testthat/test-avoided-packages.R
+++ b/tests/testthat/test-avoided-packages.R
@@ -1,11 +1,17 @@
-test_that("no_obsolete_deps fails when DESCRIPTION depends on obsolete package", {
+test_that("no_obsolete_deps fails when DESCRIPTION depends on obsolete pkg", {
   pkg <- withr::local_tempdir()
   dir.create(file.path(pkg, "R"))
-  writeLines(c(
-    "Package: badpkg", "Title: Test", "Version: 1.0.0",
-    "Description: Test.", "License: MIT",
-    "Imports: sp"
-  ), file.path(pkg, "DESCRIPTION"))
+  writeLines(
+    c(
+      "Package: badpkg",
+      "Title: Test",
+      "Version: 1.0.0",
+      "Description: Test.",
+      "License: MIT",
+      "Imports: sp"
+    ),
+    file.path(pkg, "DESCRIPTION")
+  )
   writeLines("f <- function() 1", file.path(pkg, "R", "code.R"))
 
   gp_res <- gp(pkg, checks = "no_obsolete_deps")
@@ -26,11 +32,17 @@ test_that("no_obsolete_deps passes with no obsolete dependencies", {
 test_that("no_obsolete_deps catches multiple obsolete packages", {
   pkg <- withr::local_tempdir()
   dir.create(file.path(pkg, "R"))
-  writeLines(c(
-    "Package: badpkg2", "Title: Test", "Version: 1.0.0",
-    "Description: Test.", "License: MIT",
-    "Imports: RCurl, XML"
-  ), file.path(pkg, "DESCRIPTION"))
+  writeLines(
+    c(
+      "Package: badpkg2",
+      "Title: Test",
+      "Version: 1.0.0",
+      "Description: Test.",
+      "License: MIT",
+      "Imports: RCurl, XML"
+    ),
+    file.path(pkg, "DESCRIPTION")
+  )
   writeLines("f <- function() 1", file.path(pkg, "R", "code.R"))
 
   gp_res <- gp(pkg, checks = "no_obsolete_deps")
@@ -50,11 +62,17 @@ test_that("no_obsolete_deps returns NA on description error", {
 test_that("no_obsolete_deps gp message lists found packages", {
   pkg <- withr::local_tempdir()
   dir.create(file.path(pkg, "R"))
-  writeLines(c(
-    "Package: msgtest", "Title: Test", "Version: 1.0.0",
-    "Description: Test.", "License: MIT",
-    "Imports: rjson"
-  ), file.path(pkg, "DESCRIPTION"))
+  writeLines(
+    c(
+      "Package: msgtest",
+      "Title: Test",
+      "Version: 1.0.0",
+      "Description: Test.",
+      "License: MIT",
+      "Imports: rjson"
+    ),
+    file.path(pkg, "DESCRIPTION")
+  )
   writeLines("f <- function() 1", file.path(pkg, "R", "code.R"))
 
   gp_res <- gp(pkg, checks = "no_obsolete_deps")

--- a/tests/testthat/test-avoided-packages.R
+++ b/tests/testthat/test-avoided-packages.R
@@ -50,7 +50,7 @@ test_that("no_obsolete_deps catches multiple obsolete packages", {
   expect_false(res$passed[res$check == "no_obsolete_deps"])
 
   pos <- failed_positions(gp_res)$no_obsolete_deps
-  expect_equal(length(pos), 2)
+  expect_length(pos, 2)
 })
 
 test_that("no_obsolete_deps returns NA on description error", {

--- a/tests/testthat/test-check-selection.R
+++ b/tests/testthat/test-check-selection.R
@@ -12,7 +12,7 @@ test_that("all_check_groups returns registered group names", {
 
 test_that("checks_by_group returns checks for a single group", {
   desc_checks <- checks_by_group("description")
-  expect_true(length(desc_checks) > 0)
+  expect_gt(length(desc_checks), 0)
   expect_true("description_url" %in% desc_checks)
   expect_false("lintr_assignment_linter" %in% desc_checks)
   expect_true(all(desc_checks %in% all_checks()))
@@ -52,7 +52,7 @@ test_that("all check groups map to registered preps", {
 test_that("checks with multiple groups are known", {
   lens <- vapply(CHECKS, function(ch) length(ch$preps), integer(1L))
   multi <- names(lens[lens >= 2])
-  expect_true(length(multi) >= 3)
+  expect_gte(length(multi), 3)
   expect_true("rd_has_examples" %in% multi)
   expect_true("rd_has_return" %in% multi)
   expect_true("reverse_dependencies" %in% multi)
@@ -68,8 +68,8 @@ test_that("all tidyverse checks belong to the tidyverse group", {
 test_that("code_structure and package_structure are distinct", {
   cs <- checks_by_group("code_structure")
   ps <- checks_by_group("package_structure")
-  expect_true(length(cs) > 0)
-  expect_true(length(ps) > 0)
+  expect_gt(length(cs), 0)
+  expect_gt(length(ps), 0)
   expect_length(intersect(cs, ps), 0)
   expect_true("print_return_invisible" %in% cs)
   expect_true("has_readme" %in% ps)
@@ -79,6 +79,6 @@ test_that("checks_by_group works in gp()", {
   pkg_path <- system.file("bad1", package = "goodpractice")
   g <- gp(pkg_path, checks = checks_by_group("description"))
   res <- results(g)
-  expect_true(nrow(res) > 0)
+  expect_gt(nrow(res), 0)
   expect_true(all(res$check %in% checks_by_group("description")))
 })

--- a/tests/testthat/test-complexity.R
+++ b/tests/testthat/test-complexity.R
@@ -1,4 +1,4 @@
-# -- complexity_function_length ----------------------------------------------------------
+# -- complexity_function_length -----------------------------------------------
 
 test_that("complexity_function_length fails on long functions", {
   pkg <- withr::local_tempdir()
@@ -8,7 +8,9 @@ test_that("complexity_function_length fails on long functions", {
     "Description: Test.", "License: MIT"
   ), file.path(pkg, "DESCRIPTION"))
 
-  body <- paste(paste0("  x", seq_len(60), " <- ", seq_len(60)), collapse = "\n")
+  body <- paste(
+    paste0("  x", seq_len(60), " <- ", seq_len(60)), collapse = "\n"
+  )
   writeLines(
     paste0("big_fn <- function() {\n", body, "\n}"),
     file.path(pkg, "R", "big.R")
@@ -36,7 +38,9 @@ test_that("complexity_function_length respects custom limit option", {
     "Description: Test.", "License: MIT"
   ), file.path(pkg, "DESCRIPTION"))
 
-  body <- paste(paste0("  x", seq_len(10), " <- ", seq_len(10)), collapse = "\n")
+  body <- paste(
+    paste0("  x", seq_len(10), " <- ", seq_len(10)), collapse = "\n"
+  )
   writeLines(
     paste0("medium_fn <- function() {\n", body, "\n}"),
     file.path(pkg, "R", "medium.R")

--- a/tests/testthat/test-complexity.R
+++ b/tests/testthat/test-complexity.R
@@ -71,13 +71,13 @@ test_that("ts_function_length counts lines correctly", {
   tree <- treesitter::parser_parse(p, code)
   root <- treesitter::tree_root_node(tree)
   fns <- ts_file_functions(root, "test.R")
-  expect_equal(ts_function_length(fns[[1]]$fn_node), 4L)
+  expect_identical(ts_function_length(fns[[1]]$fn_node), 4L)
 })
 
 test_that("ts_all_referenced_functions returns empty for no trees", {
   pkg <- withr::local_tempdir()
   ts <- ts_parse(pkg)
-  expect_equal(ts_all_referenced_functions(ts), character())
+  expect_identical(ts_all_referenced_functions(ts), character())
 })
 
 test_that("ts_all_referenced_functions extracts call names", {

--- a/tests/testthat/test-coverage.R
+++ b/tests/testthat/test-coverage.R
@@ -33,5 +33,5 @@ test_that("run_prep_step passes multiple ... args to fn", {
   state <- run_prep_step(state, "test", function(a, b, c) {
     list(sum = a + b + c)
   }, a = 1, b = 2, c = 3)
-  expect_equal(state$test$sum, 6)
+  expect_identical(state$test$sum, 6)
 })

--- a/tests/testthat/test-custom.R
+++ b/tests/testthat/test-custom.R
@@ -14,7 +14,7 @@ test_that("extra check", {
   res <- gp(bad1, checks = "simple_tf",
             extra_checks = list(simple_tf = simple_truefalse_not_tf))
 
-  expect_equal(checks(res), "simple_tf")
+  expect_identical(checks(res), "simple_tf")
   expect_false(results(res)$passed)
 
 })
@@ -35,7 +35,7 @@ test_that("extra prep and check pair", {
             extra_preps = list(desc = make_prep("desc", url_prep)),
             extra_checks = list(url = url_chk))
 
-  expect_equal(checks(res), c("no_description_depends", "url"))
-  expect_equal(results(res)$passed, rep(FALSE, 2))
+  expect_identical(checks(res), c("no_description_depends", "url"))
+  expect_identical(results(res)$passed, rep(FALSE, 2))
 
 })

--- a/tests/testthat/test-description.R
+++ b/tests/testthat/test-description.R
@@ -155,7 +155,10 @@ test_that("all checks return NA on try-error state", {
   for (nm in check_names) {
     result <- CHECKS[[nm]]$check(state)
     expect_identical(result$status, NA, label = paste(nm, "on try-error"))
-    expect_identical(result$positions, list(), label = paste(nm, "positions on try-error"))
+    expect_identical(
+      result$positions, list(),
+      label = paste(nm, "positions on try-error")
+    )
   }
 })
 

--- a/tests/testthat/test-duplicate-docs.R
+++ b/tests/testthat/test-duplicate-docs.R
@@ -1,4 +1,4 @@
-test_that("duplicate_function_bodies fails on identical functions across files", {
+test_that("duplicate_function_bodies fails on identical fns across files", {
   pkg <- withr::local_tempdir()
   dir.create(file.path(pkg, "R"))
   writeLines(c(

--- a/tests/testthat/test-exclude-path.R
+++ b/tests/testthat/test-exclude-path.R
@@ -7,20 +7,20 @@ test_that("excluded_paths returns empty by default", {
 test_that("excluded_paths reads from option", {
   withr::local_options(goodpractice.exclude_path = c("R/a.R", "R/b.R"))
   result <- excluded_paths()
-  expect_equal(result, c("R/a.R", "R/b.R"))
+  expect_identical(result, c("R/a.R", "R/b.R"))
 })
 
 test_that("excluded_paths reads from envvar", {
   withr::local_options(goodpractice.exclude_path = NULL)
   withr::local_envvar(GP_EXCLUDE_PATH = "R/a.R,R/b.R")
   result <- excluded_paths()
-  expect_equal(result, c("R/a.R", "R/b.R"))
+  expect_identical(result, c("R/a.R", "R/b.R"))
 })
 
 test_that("excluded_paths option takes precedence over envvar", {
   withr::local_options(goodpractice.exclude_path = "R/from_option.R")
   withr::local_envvar(GP_EXCLUDE_PATH = "R/from_envvar.R")
-  expect_equal(excluded_paths(), "R/from_option.R")
+  expect_identical(excluded_paths(), "R/from_option.R")
 })
 
 test_that("filter_excluded_paths removes matching files", {
@@ -32,19 +32,19 @@ test_that("filter_excluded_paths removes matching files", {
 
   files <- file.path(tmp, "R", c("a.R", "b.R", "c.R"))
   result <- filter_excluded_paths(files, tmp, "R/a.R")
-  expect_equal(basename(result), c("b.R", "c.R"))
+  expect_identical(basename(result), c("b.R", "c.R"))
 })
 
 test_that("filter_excluded_paths with empty exclude returns all files", {
   files <- c("/tmp/R/a.R", "/tmp/R/b.R")
   result <- filter_excluded_paths(files, "/tmp", character())
-  expect_equal(result, files)
+  expect_identical(result, files)
 })
 
 test_that("exclude_path filters roxygen2 blocks", {
   withr::local_options(goodpractice.exclude_path = "R/functions.R")
   g <- gp("good", checks = "roxygen2_has_export_or_nord")
-  expect_equal(g$exclude_path, "R/functions.R")
+  expect_identical(g$exclude_path, "R/functions.R")
 })
 
 test_that("gp passes exclude_path to state", {
@@ -53,5 +53,5 @@ test_that("gp passes exclude_path to state", {
   g <- gp(pkg, checks = "print_return_invisible")
   res <- results(g)
   expect_true("print_return_invisible" %in% res$check)
-  expect_equal(g$exclude_path, "R/functions.R")
+  expect_identical(g$exclude_path, "R/functions.R")
 })

--- a/tests/testthat/test-gp.R
+++ b/tests/testthat/test-gp.R
@@ -7,7 +7,7 @@ test_that("gp errors when DESCRIPTION is missing", {
 
 test_that("validate_pkg_path returns package name", {
   bad1 <- system.file("bad1", package = "goodpractice")
-  expect_equal(
+  expect_identical(
     unname(validate_pkg_path(bad1)), "badpackage"
   )
 })
@@ -22,7 +22,7 @@ test_that("validate_pkg_path errors for non-package path", {
 test_that("resolve_checks returns checks when provided", {
   mychecks <- prepare_checks(CHECKS, NULL)
   result <- resolve_checks("has_readme", mychecks)
-  expect_equal(result, "has_readme")
+  expect_identical(result, "has_readme")
 })
 
 test_that("resolve_checks applies exclusions when NULL", {
@@ -41,14 +41,14 @@ test_that("resolve_checks applies exclusions when NULL", {
 test_that("required_preps returns unique prep names", {
   mychecks <- prepare_checks(CHECKS, NULL)
   preps <- required_preps("description_url", mychecks)
-  expect_equal(preps, "description")
+  expect_identical(preps, "description")
 })
 
 test_that("required_preps deduplicates across checks", {
   mychecks <- prepare_checks(CHECKS, NULL)
   checks <- c("description_url", "no_description_depends")
   preps <- required_preps(checks, mychecks)
-  expect_equal(preps, "description")
+  expect_identical(preps, "description")
 })
 
 # -- init_state ---------------------------------------------------------------
@@ -56,8 +56,8 @@ test_that("required_preps deduplicates across checks", {
 test_that("init_state creates proper state list", {
   bad1 <- system.file("bad1", package = "goodpractice")
   state <- init_state(bad1, "badpackage", NULL, NULL)
-  expect_equal(state$path, bad1)
-  expect_equal(unname(state$package), "badpackage")
+  expect_identical(state$path, bad1)
+  expect_identical(unname(state$package), "badpackage")
   expect_true(is.environment(state$.cache))
 })
 
@@ -166,7 +166,7 @@ test_that("empty exclusion returns checks unchanged", {
   withr::local_envvar(GP_EXCLUDE_CHECK_GROUPS = "")
   checks <- c("no_description_depends", "covr")
   result <- exclude_checks_by_group(checks, CHECKS)
-  expect_equal(result, checks)
+  expect_identical(result, checks)
 })
 
 test_that(".cache is removed from gp result", {

--- a/tests/testthat/test-gp.R
+++ b/tests/testthat/test-gp.R
@@ -106,7 +106,7 @@ test_that("check_failed is the inverse of check_passed", {
   expect_false(check_failed(list(status = TRUE)))
 })
 
-# -- exclude_checks_by_group ----------------------------------------------------
+# -- exclude_checks_by_group -------------------------------------------------
 
 test_that("option excludes checks by group name", {
   bad1 <- system.file("bad1", package = "goodpractice")

--- a/tests/testthat/test-integrity.R
+++ b/tests/testthat/test-integrity.R
@@ -1,6 +1,4 @@
-
 test_that("checks are not overwritten", {
-
   skip_on_cran()
 
   pkgdir <- file.path("..", "..", "R")
@@ -8,5 +6,5 @@ test_that("checks are not overwritten", {
   rlines <- as.character(unlist(lapply(rfiles, readLines)))
   rwords <- unlist(strsplit(rlines, "\\s+"))
   checks <- grep("CHECKS$", rwords, fixed = TRUE, value = TRUE)
-  expect_false(any(duplicated(checks)))
+  expect_identical(anyDuplicated(checks), 0L)
 })

--- a/tests/testthat/test-lintr.R
+++ b/tests/testthat/test-lintr.R
@@ -96,7 +96,7 @@ test_that("all new lintr checks run and return results", {
   all_lintr <- grep("^lintr_", all_checks(), value = TRUE)
   g <- gp("good", checks = all_lintr)
   res <- results(g)
-  expect_true(nrow(res) > 0)
+  expect_gt(nrow(res), 0)
   expect_true(all(all_lintr %in% res$check))
   expect_true(all(vapply(
     res$passed, function(x) is.logical(x) || is.na(x), logical(1)
@@ -107,7 +107,7 @@ test_that("make_lintr_check creates valid check", {
   chk <- make_lintr_check(
     "seq_linter", "test desc", "test gp message"
   )
-  expect_equal(chk$description, "test desc")
-  expect_equal(chk$preps, "lintr")
+  expect_identical(chk$description, "test desc")
+  expect_identical(chk$preps, "lintr")
   expect_true(is.function(chk$check))
 })

--- a/tests/testthat/test-lintr.R
+++ b/tests/testthat/test-lintr.R
@@ -76,7 +76,7 @@ test_that("get_lintr_state returns NA on try-error", {
   expect_false("position" %in% names(result))
 })
 
-test_that("lintr check functions return positions (not position) on try-error", {
+test_that("lintr check fns return positions (not position) on try-error", {
   state <- list(lintr = structure("error", class = "try-error"))
 
   res_assignment <- CHECKS$lintr_assignment_linter$check(state)
@@ -98,7 +98,9 @@ test_that("all new lintr checks run and return results", {
   res <- results(g)
   expect_true(nrow(res) > 0)
   expect_true(all(all_lintr %in% res$check))
-  expect_true(all(vapply(res$passed, function(x) is.logical(x) || is.na(x), logical(1))))
+  expect_true(all(vapply(
+    res$passed, function(x) is.logical(x) || is.na(x), logical(1)
+  )))
 })
 
 test_that("make_lintr_check creates valid check", {

--- a/tests/testthat/test-namespace.R
+++ b/tests/testthat/test-namespace.R
@@ -5,12 +5,17 @@ test_that("namespace checks return NA on try-error state", {
 
   for (nm in c("no_import_package_as_a_whole", "no_export_pattern")) {
     result <- CHECKS[[nm]]$check(state)
-    expect_identical(result$status, NA, label = paste(nm, "status on try-error"))
-    expect_identical(result$positions, list(), label = paste(nm, "positions on try-error"))
+    expect_identical(
+      result$status, NA, label = paste(nm, "status on try-error")
+    )
+    expect_identical(
+      result$positions, list(),
+      label = paste(nm, "positions on try-error")
+    )
   }
 })
 
-test_that("no_import_package_as_a_whole returns list with status and positions", {
+test_that("no_import_package_as_a_whole returns status and positions", {
   state <- list(namespace = list(
     imports = list(c("pkg1", "fun1"), c("pkg2", "fun2", "fun3"))
   ))

--- a/tests/testthat/test-prep-expressions.R
+++ b/tests/testthat/test-prep-expressions.R
@@ -19,12 +19,12 @@ test_that("package_collate returns file list when Collate exists", {
   )
 
   result <- package_collate(pkg)
-  expect_equal(result, "f.R")
+  expect_identical(result, "f.R")
 })
 
 test_that("r_package_files returns R files for fixture package", {
   files <- r_package_files("good")
-  expect_true(length(files) > 0)
+  expect_gt(length(files), 0)
   expect_true(all(grepl("\\.R$", files, ignore.case = TRUE)))
 })
 
@@ -32,4 +32,3 @@ test_that("r_package_files includes full path", {
   files <- r_package_files("good")
   expect_true(all(grepl("good/R/", files)))
 })
-

--- a/tests/testthat/test-print.R
+++ b/tests/testthat/test-print.R
@@ -58,10 +58,10 @@ test_that("gp_positions includes column when available", {
 })
 
 test_that("check_type extracts type from result", {
-  expect_equal(check_type(TRUE), "error")
-  expect_equal(check_type(list(status = TRUE)), "error")
-  expect_equal(check_type(list(status = TRUE, type = "info")), "info")
-  expect_equal(check_type(list(status = FALSE, type = "warning")), "warning")
+  expect_identical(check_type(TRUE), "error")
+  expect_identical(check_type(list(status = TRUE)), "error")
+  expect_identical(check_type(list(status = TRUE, type = "info")), "info")
+  expect_identical(check_type(list(status = FALSE, type = "warning")), "warning")
 })
 
 test_that("print shows info messages with praise", {

--- a/tests/testthat/test-rd-checks.R
+++ b/tests/testthat/test-rd-checks.R
@@ -8,7 +8,7 @@ test_that("rd_find_topic returns topic when alias matches", {
     list(aliases = "baz", file = "baz.Rd")
   )
   result <- rd_find_topic(rd_data, "baz")
-  expect_equal(result$file, "baz.Rd")
+  expect_identical(result$file, "baz.Rd")
 })
 
 test_that("rd_find_topic returns NULL when no alias matches", {
@@ -26,12 +26,12 @@ test_that("rd_exported_aliases returns exports minus S3 methods", {
     S3methods = matrix(c("print", "myclass", "print.myclass"), ncol = 3)
   ))
   result <- rd_exported_aliases(state)
-  expect_equal(result, "foo")
+  expect_identical(result, "foo")
 })
 
 test_that("rd_exported_aliases returns empty on try-error namespace", {
   state <- list(namespace = structure("error", class = "try-error"))
-  expect_equal(rd_exported_aliases(state), character())
+  expect_identical(rd_exported_aliases(state), character())
 })
 
 test_that("rd_exported_aliases handles empty S3methods matrix", {
@@ -40,7 +40,7 @@ test_that("rd_exported_aliases handles empty S3methods matrix", {
     S3methods = matrix(character(0), ncol = 3)
   ))
   result <- rd_exported_aliases(state)
-  expect_equal(result, c("foo", "bar"))
+  expect_identical(result, c("foo", "bar"))
 })
 
 # -- make_rd_check: direct unit tests ----------------------------------------
@@ -73,8 +73,8 @@ test_that("make_rd_check fails when exported topic lacks field", {
   result <- CHECKS$rd_has_examples$check(state)
   expect_false(result$status)
   expect_length(result$positions, 1)
-  expect_equal(result$positions[[1]]$filename, "man/myfun.Rd")
-  expect_equal(result$positions[[1]]$line, "myfun")
+  expect_identical(result$positions[[1]]$filename, "man/myfun.Rd")
+  expect_identical(result$positions[[1]]$line, "myfun")
 })
 
 test_that("make_rd_check returns NA on empty rd_data", {
@@ -112,7 +112,7 @@ test_that("make_rd_check creates a working check", {
     gp = "test advice",
     field = "has_examples"
   )
-  expect_equal(chk$description, "test check")
+  expect_identical(chk$description, "test check")
   expect_true("documentation" %in% chk$tags)
 
   state <- list(
@@ -210,7 +210,7 @@ test_that("rd_has_return still flags exported non-internal without value", {
   result <- CHECKS$rd_has_return$check(state)
   expect_false(result$status)
   expect_length(result$positions, 1)
-  expect_equal(result$positions[[1]]$line, "public_fn")
+  expect_identical(result$positions[[1]]$line, "public_fn")
 })
 
 test_that("rd_has_return does not flag keyword internal in bad_rd fixture", {
@@ -244,12 +244,12 @@ test_that("all rd checks return na_result when prep failed", {
 # -- parse_rd_files -----------------------------------------------------------
 
 test_that("parse_rd_files returns empty list when mandir does not exist", {
-  expect_equal(parse_rd_files(tempfile()), list())
+  expect_identical(parse_rd_files(tempfile()), list())
 })
 
 test_that("parse_rd_files returns empty list when mandir has no .Rd files", {
   d <- withr::local_tempdir()
-  expect_equal(parse_rd_files(d), list())
+  expect_identical(parse_rd_files(d), list())
 })
 
 test_that("parse_rd_files parses Rd files correctly", {
@@ -292,7 +292,7 @@ test_that("parse_rd_files handles Rd elements with no Rd_tag attribute", {
   writeLines("placeholder", file.path(d, "myfun.Rd"))
   result <- parse_rd_files(d)
   expect_length(result, 1)
-  expect_equal(result[[1]]$aliases, "myfun")
+  expect_identical(result[[1]]$aliases, "myfun")
 })
 
 # -- PREPS$rd -----------------------------------------------------------------

--- a/tests/testthat/test-revdep.R
+++ b/tests/testthat/test-revdep.R
@@ -26,8 +26,8 @@ describe("reverse_dependencies check", {
     state <- make_desc_state()
     result <- CHECKS$reverse_dependencies$check(state)
     expect_true(result$status)
-    expect_equal(result$type, "info")
-    expect_equal(result$revdeps, c("pkgA", "pkgB"))
+    expect_identical(result$type, "info")
+    expect_identical(result$revdeps, c("pkgA", "pkgB"))
   })
 
   it("returns na_result on query error", {
@@ -119,12 +119,12 @@ describe("query_reverse_deps", {
     )
     local_mocked_bindings(
       package_dependencies = function(pkg, db, reverse) {
-        list(testpkg = c("pkgA"))
+        list(testpkg = "pkgA")
       },
       .package = "tools"
     )
     result <- query_reverse_deps("testpkg", fake_db)
-    expect_equal(result, "pkgA")
+    expect_identical(result, "pkgA")
   })
 
   it("returns NULL when no reverse deps", {
@@ -150,4 +150,3 @@ describe("revdep prep", {
     expect_true(identical(state$revdep, NA))
   })
 })
-

--- a/tests/testthat/test-revdep.R
+++ b/tests/testthat/test-revdep.R
@@ -68,7 +68,9 @@ describe("reverse_dependencies check", {
   })
 
   it("passes when package has zero reverse deps (empty character)", {
-    local_mocked_bindings(query_reverse_deps = function(pkg_name, db) character(0))
+    local_mocked_bindings(
+      query_reverse_deps = function(pkg_name, db) character(0)
+    )
     state <- make_desc_state()
     result <- CHECKS$reverse_dependencies$check(state)
     expect_true(result$status)
@@ -116,7 +118,9 @@ describe("query_reverse_deps", {
       dimnames = list("pkgA", c("Package", "Version", "Depends"))
     )
     local_mocked_bindings(
-      package_dependencies = function(pkg, db, reverse) list(testpkg = c("pkgA")),
+      package_dependencies = function(pkg, db, reverse) {
+        list(testpkg = c("pkgA"))
+      },
       .package = "tools"
     )
     result <- query_reverse_deps("testpkg", fake_db)

--- a/tests/testthat/test-roxygen2.R
+++ b/tests/testthat/test-roxygen2.R
@@ -20,7 +20,7 @@ test_that("roxygen2 checks return NA for non-roxygen2 packages", {
 
 # -- roxygen2_has_export_or_nord ----------------------------------------------
 
-test_that("roxygen2_has_export_or_nord flags documented functions missing tags", {
+test_that("roxygen2_has_export_or_nord flags documented fns missing tags", {
   gp_res <- gp("bad_roxygen", checks = "roxygen2_has_export_or_nord")
   expect_false(results(gp_res)$passed)
 
@@ -185,7 +185,7 @@ test_that("find_function_defs returns empty data.frame when no R files exist", {
 
 # -- find_function_defs edge cases --------------------------------------------
 
-test_that("find_function_defs returns empty data.frame when no functions found", {
+test_that("find_function_defs returns empty data.frame when no fns found", {
   pkg <- withr::local_tempdir("no_fns")
   dir.create(file.path(pkg, "R"))
   writeLines("x <- 1", file.path(pkg, "R", "data.R"))
@@ -250,7 +250,10 @@ test_that("parse_roxygen2 handles broken NAMESPACE gracefully", {
       "Description: Test.", "License: MIT", "RoxygenNote: 7.3.3"),
     file.path(pkg, "DESCRIPTION")
   )
-  writeLines("this is not valid namespace content!!!", file.path(pkg, "NAMESPACE"))
+  writeLines(
+    "this is not valid namespace content!!!",
+    file.path(pkg, "NAMESPACE")
+  )
 
   result <- parse_roxygen2(pkg)
   expect_equal(result$namespace_exports, character())

--- a/tests/testthat/test-roxygen2.R
+++ b/tests/testthat/test-roxygen2.R
@@ -160,12 +160,12 @@ test_that("find_function_defs returns data.frame with correct columns", {
   result <- find_function_defs(pkg)
   expect_s3_class(result, "data.frame")
   expect_named(result, c("name", "file", "line"))
-  expect_equal(nrow(result), 2)
+  expect_identical(nrow(result), 2L)
   expect_true(all(c("alpha", "beta") %in% result$name))
   expect_true(all(grepl("fns\\.R$", result$file)))
   expect_true(is.numeric(result$line))
-  expect_equal(result$line[result$name == "alpha"], 1L)
-  expect_equal(result$line[result$name == "beta"], 2L)
+  expect_identical(result$line[result$name == "alpha"], 1)
+  expect_identical(result$line[result$name == "beta"], 2)
 })
 
 test_that("find_function_defs returns empty data.frame when no R files exist", {
@@ -179,7 +179,7 @@ test_that("find_function_defs returns empty data.frame when no R files exist", {
 
   result <- find_function_defs(pkg)
   expect_s3_class(result, "data.frame")
-  expect_equal(nrow(result), 0)
+  expect_identical(nrow(result), 0L)
   expect_named(result, c("name", "file", "line"))
 })
 
@@ -196,7 +196,7 @@ test_that("find_function_defs returns empty data.frame when no fns found", {
   )
 
   result <- find_function_defs(pkg)
-  expect_equal(nrow(result), 0)
+  expect_identical(nrow(result), 0L)
   expect_named(result, c("name", "file", "line"))
 })
 
@@ -216,8 +216,8 @@ test_that("find_function_defs skips non-identifier LHS assignments", {
   )
 
   result <- find_function_defs(pkg)
-  expect_equal(nrow(result), 1)
-  expect_equal(result$name, "real_fn")
+  expect_identical(nrow(result), 1L)
+  expect_identical(result$name, "real_fn")
 })
 
 test_that("find_function_defs skips non-existent files", {
@@ -232,8 +232,8 @@ test_that("find_function_defs skips non-existent files", {
   )
 
   result <- find_function_defs(pkg)
-  expect_equal(nrow(result), 1)
-  expect_equal(result$name, "my_fn")
+  expect_identical(nrow(result), 1L)
+  expect_identical(result$name, "my_fn")
 })
 
 # -- parse_roxygen2 NAMESPACE error fallback ----------------------------------
@@ -256,8 +256,8 @@ test_that("parse_roxygen2 handles broken NAMESPACE gracefully", {
   )
 
   result <- parse_roxygen2(pkg)
-  expect_equal(result$namespace_exports, character())
-  expect_equal(result$namespace_s3methods, character())
+  expect_identical(result$namespace_exports, character())
+  expect_identical(result$namespace_s3methods, character())
 })
 
 # -- parse_roxygen2 S3 methods ------------------------------------------------

--- a/tests/testthat/test-rstudio-markers.R
+++ b/tests/testthat/test-rstudio-markers.R
@@ -17,7 +17,7 @@ test_that("get_marker returns NULL when no positions field", {
 test_that("get_marker returns position list for failing check", {
   result <- get_marker(gp_obj, "r_file_extension")
   expect_type(result, "list")
-  expect_true(length(result) > 0)
+  expect_gt(length(result), 0)
   expect_true(all(
     c("type", "file", "line", "column", "message") %in%
       names(result[[1]])
@@ -29,14 +29,14 @@ test_that("get_marker handles NA line_number and column_number", {
   state$checks$r_file_extension$positions[[1]]$line_number <- NA
   state$checks$r_file_extension$positions[[1]]$column_number <- NA
   result <- get_marker(state, "r_file_extension")
-  expect_equal(result[[1]]$line, 1L)
-  expect_equal(result[[1]]$column, 1L)
+  expect_identical(result[[1]]$line, 1L)
+  expect_identical(result[[1]]$column, 1L)
 })
 
 test_that("get_markers collects markers from all failing checks", {
   markers <- get_markers(gp_obj)
   expect_type(markers, "list")
-  expect_true(length(markers) > 0)
+  expect_gt(length(markers), 0)
 })
 
 test_that("get_markers returns empty for all-pass results", {

--- a/tests/testthat/test-spelling.R
+++ b/tests/testthat/test-spelling.R
@@ -20,5 +20,5 @@ test_that("spelling returns NA when no inst/WORDLIST exists", {
   state <- list(spelling = "no_wordlist")
   result <- CHECKS$spelling$check(state)
   expect_true(is.na(result$status))
-  expect_equal(result$positions, list())
+  expect_identical(result$positions, list())
 })

--- a/tests/testthat/test-tidyverse.R
+++ b/tests/testthat/test-tidyverse.R
@@ -11,14 +11,14 @@ gp_good <- gp("good_tidyverse", checks = tv_checks)
 res_good <- results(gp_good)
 
 test_that("tidyverse_checks() returns only tidyverse_ prefixed checks", {
-  expect_true(length(tv_checks) > 0)
+  expect_gt(length(tv_checks), 0)
   expect_true(all(grepl("^tidyverse_", tv_checks)))
 })
 
 test_that("default_checks() excludes tidyverse checks", {
   dc <- default_checks()
   expect_false(any(grepl("^tidyverse_", dc)))
-  expect_equal(sort(c(dc, tv_checks)), sort(all_checks()))
+  expect_identical(sort(c(dc, tv_checks)), sort(all_checks()))
 })
 
 test_that("tidyverse lintr checks pass on good fixture", {
@@ -190,7 +190,7 @@ test_that("get_tidyverse_lintr_state returns NA on try-error", {
   state <- list(tidyverse_lintr = structure("error", class = "try-error"))
   result <- get_tidyverse_lintr_state(state, "brace_linter")
   expect_true(is.na(result$status))
-  expect_equal(result$positions, list())
+  expect_identical(result$positions, list())
 })
 
 test_that("tidyverse_no_missing ignores missing() inside nested functions", {

--- a/tests/testthat/test-tidyverse.R
+++ b/tests/testthat/test-tidyverse.R
@@ -47,7 +47,9 @@ test_that("tidyverse equals_na_linter fails on bad fixture", {
 })
 
 test_that("tidyverse function_left_parentheses_linter fails on bad fixture", {
-  expect_false(get_result(res_bad, "tidyverse_function_left_parentheses_linter"))
+  expect_false(
+    get_result(res_bad, "tidyverse_function_left_parentheses_linter")
+  )
 })
 
 test_that("tidyverse indentation_linter fails on bad fixture", {
@@ -301,7 +303,7 @@ test_that("tidyverse prep passes exclude_path as exclusions", {
   expect_true(res$passed[res$check == "tidyverse_assignment_linter"])
 })
 
-test_that("tidyverse prep returns try-error with warning on lint_package failure", {
+test_that("tidyverse prep returns try-error with warning on lint failure", {
   state <- list(path = withr::local_tempdir(), exclude_path = character())
   local_mocked_bindings(lint_package = function(...) stop("lint failure"))
   expect_warning(

--- a/tests/testthat/test-treesitter.R
+++ b/tests/testthat/test-treesitter.R
@@ -7,17 +7,17 @@ test_that("ts_parse extracts functions from a package", {
   expect_true("functions" %in% names(ts))
   expect_true("language" %in% names(ts))
 
-  expect_true(length(ts$functions) > 0)
+  expect_gt(length(ts$functions), 0)
   fn <- ts$functions[[1]]
   expect_true(all(c("name", "file", "line", "fn_node") %in% names(fn)))
-  expect_equal(fn$name, "func1")
+  expect_identical(fn$name, "func1")
 })
 
 test_that("ts_parse returns empty lists when no R directory", {
   pkg <- withr::local_tempdir()
   ts <- ts_parse(pkg)
-  expect_equal(ts$trees, list())
-  expect_equal(ts$functions, list())
+  expect_identical(ts$trees, list())
+  expect_identical(ts$functions, list())
 })
 
 # -- ts_file_functions --------------------------------------------------------
@@ -30,12 +30,12 @@ test_that("ts_file_functions finds top-level function definitions", {
   root <- treesitter::tree_root_node(tree)
 
   fns <- ts_file_functions(root, "test.R")
-  expect_equal(length(fns), 2)
-  expect_equal(fns[[1]]$name, "foo")
-  expect_equal(fns[[2]]$name, "bar")
-  expect_equal(fns[[1]]$file, "test.R")
-  expect_equal(fns[[1]]$line, 1L)
-  expect_equal(fns[[2]]$line, 2L)
+  expect_length(fns, 2)
+  expect_identical(fns[[1]]$name, "foo")
+  expect_identical(fns[[2]]$name, "bar")
+  expect_identical(fns[[1]]$file, "test.R")
+  expect_identical(fns[[1]]$line, 1)
+  expect_identical(fns[[2]]$line, 2)
 })
 
 test_that("ts_file_functions skips non-function assignments", {
@@ -46,7 +46,7 @@ test_that("ts_file_functions skips non-function assignments", {
   root <- treesitter::tree_root_node(tree)
 
   fns <- ts_file_functions(root, "test.R")
-  expect_equal(length(fns), 0)
+  expect_length(fns, 0)
 })
 
 test_that("ts_file_functions skips non-identifier LHS", {
@@ -57,8 +57,8 @@ test_that("ts_file_functions skips non-identifier LHS", {
   root <- treesitter::tree_root_node(tree)
 
   fns <- ts_file_functions(root, "test.R")
-  expect_equal(length(fns), 1)
-  expect_equal(fns[[1]]$name, "real_fn")
+  expect_length(fns, 1)
+  expect_identical(fns[[1]]$name, "real_fn")
 })
 
 test_that("ts_parse finds functions in .S files", {
@@ -136,7 +136,7 @@ test_that("ts_body_has_call ignores calls inside nested functions", {
 test_that("ts_get caches treesitter parse result", {
   state <- list(path = "good", .cache = list())
   ts1 <- ts_get(state)
-  expect_true(length(ts1$functions) > 0)
+  expect_gt(length(ts1$functions), 0)
 
   state$.cache$treesitter <- ts1
   ts2 <- ts_get(state)
@@ -157,22 +157,22 @@ test_that("ts_s4_call_ranges finds setMethod call ranges", {
 
   ts <- ts_parse(pkg)
   ranges <- ts_s4_call_ranges(ts)
-  expect_equal(length(ranges), 1)
-  expect_equal(ranges[[1]]$start, 1L)
-  expect_equal(ranges[[1]]$end, 4L)
+  expect_length(ranges, 1)
+  expect_identical(ranges[[1]]$start, 1)
+  expect_identical(ranges[[1]]$end, 4)
 })
 
 test_that("ts_s4_call_ranges returns empty for no S4 calls", {
   ts <- ts_parse("good")
   ranges <- ts_s4_call_ranges(ts)
-  expect_equal(length(ranges), 0)
+  expect_length(ranges, 0)
 })
 
 test_that("ts_s4_call_ranges returns empty for no trees", {
   pkg <- withr::local_tempdir()
   ts <- ts_parse(pkg)
   ranges <- ts_s4_call_ranges(ts)
-  expect_equal(ranges, list())
+  expect_identical(ranges, list())
 })
 
 # -- full workflow (like chk_tidyverse.R) ------------------------------------
@@ -186,8 +186,8 @@ test_that("treesitter workflow finds missing() calls in functions", {
   )
 
   ts <- ts_parse(pkg)
-  expect_equal(length(ts$functions), 1)
-  expect_equal(ts$functions[[1]]$name, "check_arg")
+  expect_length(ts$functions, 1)
+  expect_identical(ts$functions[[1]]$name, "check_arg")
 
   missing_q <- treesitter::query(ts$language,
     "(call function: (identifier) @fn (#eq? @fn \"missing\"))"

--- a/tests/testthat/test-urlchecker.R
+++ b/tests/testthat/test-urlchecker.R
@@ -39,10 +39,10 @@ test_that("urlchecker_make_positions extracts first From entry as filename", {
   db <- add_from(db, list(c("DESCRIPTION", "R/foo.R"), "man/bar.Rd"))
   pos <- urlchecker_make_positions(db)
   expect_length(pos, 2)
-  expect_equal(pos[[1]]$filename, "DESCRIPTION")
-  expect_equal(pos[[2]]$filename, "man/bar.Rd")
-  expect_equal(pos[[1]]$line, "https://a.com")
-  expect_equal(pos[[2]]$line, "https://b.com")
+  expect_identical(pos[[1]]$filename, "DESCRIPTION")
+  expect_identical(pos[[2]]$filename, "man/bar.Rd")
+  expect_identical(pos[[1]]$line, "https://a.com")
+  expect_identical(pos[[2]]$line, "https://b.com")
   expect_true(is.na(pos[[1]]$line_number))
   expect_true(is.na(pos[[1]]$column_number))
 })
@@ -56,7 +56,7 @@ test_that("urlchecker_make_positions handles empty From with 'unknown'", {
   )
   db <- add_from(db, list(character()))
   pos <- urlchecker_make_positions(db)
-  expect_equal(pos[[1]]$filename, "unknown")
+  expect_identical(pos[[1]]$filename, "unknown")
 })
 
 # -- factory structure ---------------------------------------------------------
@@ -64,7 +64,7 @@ test_that("urlchecker_make_positions handles empty From with 'unknown'", {
 test_that("make_urlchecker_check produces a valid check object", {
   chk <- CHECKS$urlchecker_ok
   expect_s3_class(chk, "check")
-  expect_equal(chk$description, "All URLs are reachable")
+  expect_identical(chk$description, "All URLs are reachable")
   expect_true("urlchecker" %in% chk$preps)
   expect_true("url" %in% chk$tags)
   expect_true(is.function(chk$check))
@@ -83,7 +83,7 @@ test_that("make_urlchecker_check factory produces working checks", {
     tags = "test"
   )
   expect_s3_class(custom, "check")
-  expect_equal(custom$description, "test check")
+  expect_identical(custom$description, "test check")
   expect_true("test" %in% custom$tags)
   expect_true("urlchecker" %in% custom$preps)
 
@@ -98,7 +98,7 @@ test_that("make_urlchecker_check factory produces working checks", {
   result <- custom$check(list(urlchecker = db))
   expect_false(result$status)
   expect_length(result$positions, 1)
-  expect_equal(result$positions[[1]]$line, "https://a.com")
+  expect_identical(result$positions[[1]]$line, "https://a.com")
 
   result_pass <- custom$check(list(urlchecker = make_urlchecker_db()))
   expect_true(result_pass$status)
@@ -163,7 +163,7 @@ test_that("urlchecker_ok fails on 404", {
   result <- CHECKS$urlchecker_ok$check(state)
   expect_false(result$status)
   expect_length(result$positions, 1)
-  expect_equal(result$positions[[1]]$line, "https://example.com/gone")
+  expect_identical(result$positions[[1]]$line, "https://example.com/gone")
 })
 
 test_that("urlchecker_ok passes when all URLs return 200 or redirect", {
@@ -206,7 +206,7 @@ test_that("urlchecker_no_redirects fails when URLs redirect", {
   result <- CHECKS$urlchecker_no_redirects$check(state)
   expect_false(result$status)
   expect_length(result$positions, 1)
-  expect_equal(result$positions[[1]]$line, "https://old.com")
+  expect_identical(result$positions[[1]]$line, "https://old.com")
 })
 
 test_that("urlchecker_no_redirects passes when no redirects", {
@@ -247,7 +247,7 @@ test_that("positions report filename from From column", {
   db <- add_from(db, list(c("man/foo.Rd", "R/bar.R")))
   state <- list(urlchecker = db)
   result <- CHECKS$urlchecker_ok$check(state)
-  expect_equal(result$positions[[1]]$filename, "man/foo.Rd")
+  expect_identical(result$positions[[1]]$filename, "man/foo.Rd")
 })
 
 # -- multiple failures ---------------------------------------------------------
@@ -381,7 +381,7 @@ test_that("urlchecker_ok fails through gp() with broken URLs", {
   expect_false(res$passed[res$check == "urlchecker_ok"])
   pos <- failed_positions(gp_res)$urlchecker_ok
   expect_length(pos, 1)
-  expect_equal(pos[[1]]$line, "https://broken.com")
+  expect_identical(pos[[1]]$line, "https://broken.com")
 })
 
 test_that("urlchecker_no_redirects fails through gp() with redirects", {

--- a/tests/testthat/test-urlchecker.R
+++ b/tests/testthat/test-urlchecker.R
@@ -421,7 +421,9 @@ test_that("urlchecker checks return NA through gp() on prep failure", {
     .package = "urlchecker"
   )
   expect_warning(
-    gp_res <- gp("good", checks = c("urlchecker_ok", "urlchecker_no_redirects")),
+    gp_res <- gp(
+      "good", checks = c("urlchecker_ok", "urlchecker_no_redirects")
+    ),
     "Prep step for"
   )
   res <- results(gp_res)

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,17 +1,17 @@
 test_that("%||% returns left when non-NULL", {
-  expect_equal(1 %||% 2, 1)
-  expect_equal("a" %||% "b", "a")
+  expect_identical(1 %||% 2, 1)
+  expect_identical("a" %||% "b", "a")
 })
 
 test_that("%||% returns right when left is NULL", {
-  expect_equal(NULL %||% 2, 2)
-  expect_equal(NULL %||% "fallback", "fallback")
+  expect_identical(NULL %||% 2, 2)
+  expect_identical(NULL %||% "fallback", "fallback")
 })
 
 test_that("trim_ws removes leading and trailing whitespace", {
-  expect_equal(trim_ws("  hello  "), "hello")
-  expect_equal(trim_ws("no_ws"), "no_ws")
-  expect_equal(trim_ws("\thello\n"), "hello")
+  expect_identical(trim_ws("  hello  "), "hello")
+  expect_identical(trim_ws("no_ws"), "no_ws")
+  expect_identical(trim_ws("\thello\n"), "hello")
 })
 
 test_that("loaded_pkg_version returns a version string", {
@@ -21,8 +21,7 @@ test_that("loaded_pkg_version returns a version string", {
 })
 
 test_that("drop_nulls removes NULL elements", {
-  expect_equal(drop_nulls(list(1, NULL, 3)), list(1, 3))
-  expect_equal(drop_nulls(list(NULL, NULL)), list())
-  expect_equal(drop_nulls(list("a", "b")), list("a", "b"))
+  expect_identical(drop_nulls(list(1, NULL, 3)), list(1, 3))
+  expect_identical(drop_nulls(list(NULL, NULL)), list())
+  expect_identical(drop_nulls(list("a", "b")), list("a", "b"))
 })
-

--- a/tests/testthat/test-vignette.R
+++ b/tests/testthat/test-vignette.R
@@ -197,7 +197,9 @@ test_that("is_skipped_chunk detects quarto #| eval: false", {
   expect_true(skip_fn(c("```{r}", "#| purl: false", "x <- 1", "```"), 1, 4))
   expect_true(skip_fn(c("```{r}", "#| purl: FALSE", "x <- 1", "```"), 1, 4))
   expect_false(skip_fn(c("```{r}", "#| label: setup", "x <- 1", "```"), 1, 4))
-  expect_true(skip_fn(c("```{r}", "#| label: skip", "#| eval: false", "```"), 1, 4))
+  expect_true(skip_fn(
+    c("```{r}", "#| label: skip", "#| eval: false", "```"), 1, 4
+  ))
 })
 
 test_that("is_skipped_chunk handles empty chunk body", {

--- a/tests/testthat/test-vignette.R
+++ b/tests/testthat/test-vignette.R
@@ -114,15 +114,15 @@ test_that("vignette checks ignore #| eval: false chunks in qmd and Rmd", {
 test_that("match_chunk_pairs returns empty matrix for no starts", {
   pair_fn <- match_chunk_pairs
   result <- pair_fn(integer(0), c(5L, 10L))
-  expect_equal(nrow(result), 0)
-  expect_equal(ncol(result), 2)
+  expect_identical(nrow(result), 0L)
+  expect_identical(ncol(result), 2L)
 })
 
 test_that("match_chunk_pairs pairs starts with nearest available end", {
   pair_fn <- match_chunk_pairs
   result <- pair_fn(c(1L, 6L), c(4L, 9L))
-  expect_equal(result[, "start"], c(1L, 6L))
-  expect_equal(result[, "end"], c(4L, 9L))
+  expect_identical(result[, "start"], c(1L, 6L))
+  expect_identical(result[, "end"], c(4L, 9L))
 })
 
 test_that("match_chunk_pairs messages and returns empty on length mismatch", {
@@ -131,20 +131,20 @@ test_that("match_chunk_pairs messages and returns empty on length mismatch", {
     result <- pair_fn(c(3L), c(2L, 5L, 8L)),
     "sanity checks"
   )
-  expect_equal(nrow(result), 0)
+  expect_identical(nrow(result), 0L)
 
   expect_message(
     result <- pair_fn(c(1L, 6L, 20L), c(4L, 9L)),
     "sanity checks"
   )
-  expect_equal(nrow(result), 0)
+  expect_identical(nrow(result), 0L)
 })
 
 test_that("match_chunk_pairs skips ends consumed by earlier chunks", {
   pair_fn <- match_chunk_pairs
   result <- pair_fn(c(1L, 3L), c(2L, 5L))
-  expect_equal(result[, "start"], c(1L, 3L))
-  expect_equal(result[, "end"], c(2L, 5L))
+  expect_identical(result[, "start"], c(1L, 3L))
+  expect_identical(result[, "end"], c(2L, 5L))
 })
 
 test_that("match_chunk_pairs messages when end < start (ordering sanity)", {
@@ -153,8 +153,8 @@ test_that("match_chunk_pairs messages when end < start (ordering sanity)", {
     result <- pair_fn(c(5L), c(3L)),
     "sanity checks"
   )
-  expect_equal(nrow(result), 0)
-  expect_equal(ncol(result), 2)
+  expect_identical(nrow(result), 0L)
+  expect_identical(ncol(result), 2L)
 })
 
 test_that("match_chunk_pairs messages on overlapping chunks", {
@@ -163,8 +163,8 @@ test_that("match_chunk_pairs messages on overlapping chunks", {
     result <- pair_fn(c(1L, 3L), c(5L, 7L)),
     "sanity checks"
   )
-  expect_equal(nrow(result), 0)
-  expect_equal(ncol(result), 2)
+  expect_identical(nrow(result), 0L)
+  expect_identical(ncol(result), 2L)
 })
 
 test_that("match_chunk_pairs messages on unsorted starts", {
@@ -173,8 +173,8 @@ test_that("match_chunk_pairs messages on unsorted starts", {
     result <- pair_fn(c(6L, 1L), c(3L, 9L)),
     "sanity checks"
   )
-  expect_equal(nrow(result), 0)
-  expect_equal(ncol(result), 2)
+  expect_identical(nrow(result), 0L)
+  expect_identical(ncol(result), 2L)
 })
 
 # -- is_skipped_chunk --------------------------------------------------------
@@ -212,7 +212,7 @@ test_that("is_skipped_chunk handles empty chunk body", {
 
 test_that("vignette_files returns empty for missing vignettes dir", {
   pkg <- withr::local_tempdir()
-  expect_equal(vignette_files(pkg), character())
+  expect_identical(vignette_files(pkg), character())
 })
 
 test_that("vignette_files finds Rmd, qmd, and Rnw files", {
@@ -223,7 +223,7 @@ test_that("vignette_files finds Rmd, qmd, and Rnw files", {
   file.create(file.path(pkg, "vignettes", "c.Rnw"))
   file.create(file.path(pkg, "vignettes", "d.txt"))
   result <- vignette_files(pkg)
-  expect_equal(length(result), 3)
+  expect_length(result, 3)
   expect_true(all(grepl("\\.(Rmd|qmd|Rnw)$", result)))
 })
 
@@ -255,10 +255,10 @@ test_that("extract_vignette_code handles multiple chunks with mixed skip", {
     "```"
   ), f)
   result <- extract_vignette_code(f)
-  expect_equal(result[6], "x <- 1")
-  expect_equal(result[10], "")
-  expect_equal(result[15], "")
-  expect_equal(result[19], "w <- 4")
+  expect_identical(result[6], "x <- 1")
+  expect_identical(result[10], "")
+  expect_identical(result[15], "")
+  expect_identical(result[19], "w <- 4")
 })
 
 test_that("extract_vignette_code handles empty chunk body", {
@@ -277,8 +277,8 @@ test_that("extract_vignette_code handles empty chunk body", {
     "```"
   ), f)
   result <- extract_vignette_code(f)
-  expect_equal(result[9], "x <- 1")
-  expect_equal(result[5], "")
+  expect_identical(result[9], "x <- 1")
+  expect_identical(result[5], "")
 })
 
 test_that("extract_vignette_code returns NULL when all chunks are empty", {
@@ -339,8 +339,8 @@ test_that("extract_vignette_code handles Rnw files", {
     "\\end{document}"
   ), f)
   result <- extract_vignette_code(f)
-  expect_equal(result[4], "x <- 1")
-  expect_equal(result[1], "")
+  expect_identical(result[4], "x <- 1")
+  expect_identical(result[1], "")
 })
 
 test_that("extract_vignette_code returns NULL for unknown extension", {
@@ -405,7 +405,7 @@ test_that("safe_parse parses from file path", {
   on.exit(unlink(f))
   writeLines("x <- 1 + 2", f)
   result <- safe_parse(file = f)
-  expect_true(length(result) > 0)
+  expect_gt(length(result), 0)
 })
 
 test_that("safe_parse returns NULL when keep_source FALSE also fails", {
@@ -433,7 +433,7 @@ test_that("PREPS$vignette stores parse_data and lines", {
   ), file.path(pkg, "vignettes", "demo.Rmd"))
 
   state <- PREPS$vignette(list(path = pkg), quiet = TRUE)
-  expect_equal(length(state$vignette), 1)
+  expect_length(state$vignette, 1)
   entry <- state$vignette[[1]]
   expect_true("parse_data" %in% names(entry))
   expect_true("lines" %in% names(entry))
@@ -457,7 +457,7 @@ test_that("PREPS$vignette skips files with no parseable code", {
   ), file.path(pkg, "vignettes", "nochunks.Rmd"))
 
   state <- PREPS$vignette(list(path = pkg), quiet = TRUE)
-  expect_equal(length(state$vignette), 0)
+  expect_length(state$vignette, 0)
 })
 
 # -- call_descendants --------------------------------------------------------
@@ -468,11 +468,11 @@ test_that("call_descendants returns all nested IDs", {
   pd <- getParseData(parsed)
 
   ls_row <- pd[pd$token == "SYMBOL_FUNCTION_CALL" & pd$text == "ls", ]
-  expect_equal(nrow(ls_row), 1)
+  expect_identical(nrow(ls_row), 1L)
 
   desc_ids <- call_descendants(pd, ls_row$id[1])
   desc <- pd[pd$id %in% desc_ids, ]
-  expect_true(nrow(desc) > 0)
+  expect_gt(nrow(desc), 0)
 })
 
 # -- check_vignette_calls ---------------------------------------------------
@@ -487,14 +487,14 @@ test_that("check_vignette_calls skips rm() when nested ls() not found", {
   ))
   result <- check_vignette_calls(state, "rm", nested_fn = "ls")
   expect_true(result$status)
-  expect_equal(length(result$positions), 0)
+  expect_length(result$positions, 0)
 })
 
 test_that("check_vignette_calls passes with empty vignette state", {
   state <- list(vignette = list())
   result <- check_vignette_calls(state, "setwd")
   expect_true(result$status)
-  expect_equal(length(result$positions), 0)
+  expect_length(result$positions, 0)
 })
 
 test_that("vignette checks report correct positions", {
@@ -505,11 +505,11 @@ test_that("vignette checks report correct positions", {
   expect_true(all(vapply(rm_pos, function(p) {
     grepl("^vignettes/", p$filename)
   }, logical(1))))
-  expect_equal(rm_pos[[1]]$line_number, 10L)
+  expect_identical(rm_pos[[1]]$line_number, 10L)
 
   setwd_pos <- failed_positions(gp_res)$vignette_no_setwd
   expect_true(all(vapply(setwd_pos, function(p) {
     grepl("^vignettes/", p$filename)
   }, logical(1))))
-  expect_equal(setwd_pos[[1]]$line_number, 11L)
+  expect_identical(setwd_pos[[1]]$line_number, 11L)
 })


### PR DESCRIPTION
## Summary
- Add `.claude` to `.Rbuildignore` to prevent R CMD check NOTEs
- Fix `test-integrity.R` assertion (`anyDuplicated()` returns integer, not logical)
- Shorten long lines (>80 chars) across 13 test files
- Fix lint issues in R/ source: unnecessary lambda, negated if/else, assignment inside call, line length
- Modernize ~160 test expectations: `expect_equal()` → `expect_identical()`, `expect_true(x > y)` → `expect_gt()`, `expect_equal(length(x), n)` → `expect_length()`, remove unnecessary `c()`

## Test plan
- [x] All 733 tests pass
- [ ] Run `gp(".")` — remaining findings should only be items covered by PRs #273 and #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)