### PR TITLE
Skip implicit_assignment_linter in test files

### DIFF
--- a/R/chk_lintr.R
+++ b/R/chk_lintr.R
@@ -375,12 +375,33 @@ CHECKS$lintr_ifelse_censor_linter <- make_lintr_check(
         The dedicated functions are faster and clearer for clamping values."
 )
 
-CHECKS$lintr_implicit_assignment_linter <- make_lintr_check(
-  "implicit_assignment_linter",
-  "Avoid implicit assignments in function calls",
-  "avoid assignments inside function calls like {.code f(x <- value)}.
+CHECKS$lintr_implicit_assignment_linter <- make_check(
+
+  description = "Avoid implicit assignments in function calls",
+  tags = c("warning", "lintr"),
+  preps = "lintr",
+
+  gp = "avoid assignments inside function calls like {.code f(x <- value)}.
         Assign first, then call the function. Implicit assignments are
-        easy to miss when reading code."
+        easy to miss when reading code.",
+
+  check = function(state) {
+    if (inherits(state$lintr, "try-error")) {
+      return(na_result())
+    }
+
+    res <- get_lintr_state(state, "implicit_assignment_linter")
+
+    ## Implicit assignment is a valid testthat pattern, e.g.
+    ## expect_warning(tmp <- f()) to capture output and check for warnings.
+    ## Only flag files under R/.
+    res$positions <- Filter(
+      f = function(x) grepl("^R[/(\\\\)]", x$filename),
+      res$positions
+    )
+    res$status <- length(res$positions) == 0
+    res
+  }
 )
 
 CHECKS$lintr_inner_combine_linter <- make_lintr_check(

--- a/tests/testthat/bad2/R/attach.R
+++ b/tests/testthat/bad2/R/attach.R
@@ -22,3 +22,7 @@ lib <- function() {
 ip <- function() {
   installed.packages()
 }
+
+ia <- function() {
+  system(x <- "echo hello")
+}

--- a/tests/testthat/bad2/tests/testthat.R
+++ b/tests/testthat/bad2/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(badpackage)
+
+test_check("badpackage")

--- a/tests/testthat/bad2/tests/testthat/test-example.R
+++ b/tests/testthat/bad2/tests/testthat/test-example.R
@@ -1,0 +1,5 @@
+test_that("capture output with implicit assignment", {
+  expect_warning(
+    tmp <- att()
+  )
+})

--- a/tests/testthat/test-lintr.R
+++ b/tests/testthat/test-lintr.R
@@ -72,6 +72,19 @@ test_that("lintr_seq_linter", {
   expect_false(get_result(res_bad3, "lintr_seq_linter"))
 })
 
+test_that("lintr_implicit_assignment_linter ignores test files", {
+  gp_ia <- gp("bad2", checks = "lintr_implicit_assignment_linter")
+  res_ia <- results(gp_ia)
+  # bad2 has implicit assignment in R/ (should fail)
+  expect_false(get_result(res_ia, "lintr_implicit_assignment_linter"))
+
+  # Verify only R/ positions are reported, not tests/
+  state <- gp_ia$checks$lintr_implicit_assignment_linter
+  expect_true(all(vapply(
+    state$positions, function(x) grepl("^R[/\\\\]", x$filename), logical(1)
+  )))
+})
+
 test_that("get_lintr_state returns NA on try-error", {
   state <- list(lintr = structure("error", class = "try-error"))
   result <- get_lintr_state(state, "assignment_linter")
@@ -95,6 +108,12 @@ test_that("lintr check fns return positions (not position) on try-error", {
   expect_identical(res_library$positions, list())
   expect_true("positions" %in% names(res_library))
   expect_false("position" %in% names(res_library))
+
+  res_implicit <- CHECKS$lintr_implicit_assignment_linter$check(state)
+  expect_true(is.na(res_implicit$status))
+  expect_identical(res_implicit$positions, list())
+  expect_true("positions" %in% names(res_implicit))
+  expect_false("position" %in% names(res_implicit))
 })
 
 test_that("all new lintr checks run and return results", {


### PR DESCRIPTION
## Summary
- `implicit_assignment_linter` now only flags hits in `R/` source files, ignoring test files
- The testthat pattern `expect_warning(tmp <- f())` is a legitimate way to capture output while checking for warnings/messages/errors — this should not be flagged
- Uses the same filtering approach as `library_require_linter`

## Test plan
- [x] Added implicit assignment to `bad2/R/attach.R` — check correctly fails
- [x] Added testthat-style implicit assignment in `bad2/tests/testthat/` — correctly ignored
- [x] Added try-error guard test for the custom check function
- [x] All 751 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)