### PR TITLE
update examples for #283

### DIFF
--- a/R/api.R
+++ b/R/api.R
@@ -8,8 +8,11 @@
 #' @export
 #' @examples 
 #' path <- system.file("bad1", package = "goodpractice")
-#' # run a subset of all checks available
-#' g <- gp(path, checks = all_checks()[3:16])
+#' # Run a subset of all checks available
+#' g <- gp(path, checks = all_checks()[9:16])
+#' checks(g)
+#' # Or run with named check groups
+#' g <- gp(path, checks = checks_by_group("description", "namespace"))
 #' checks(g)
 
 checks <- function(gp) {
@@ -27,8 +30,11 @@ checks <- function(gp) {
 #' @export
 #' @examples 
 #' path <- system.file("bad1", package = "goodpractice")
-#' # run a subset of all checks available
-#' g <- gp(path, checks = all_checks()[3:16])
+#' # Run a subset of all checks available
+#' g <- gp(path, checks = all_checks()[9:16])
+#' results(g)
+#' # Or run with named check groups
+#' g <- gp(path, checks = checks_by_group("description", "namespace"))
 #' results(g)
 
 results <- function(gp) {
@@ -49,7 +55,10 @@ results <- function(gp) {
 #' @examples 
 #' path <- system.file("bad1", package = "goodpractice")
 #' # run a subset of all checks available
-#' g <- gp(path, checks = all_checks()[3:16])
+#' g <- gp(path, checks = all_checks()[9:16])
+#' failed_checks(g)
+#' # Or run with named check groups
+#' g <- gp(path, checks = checks_by_group("description", "namespace"))
 #' failed_checks(g)
 
 failed_checks <- function(gp) {

--- a/R/gp.R
+++ b/R/gp.R
@@ -74,9 +74,11 @@
 #' @importFrom desc desc_get
 #' @examples
 #' path <- system.file("bad1", package = "goodpractice")
-#' # run a subset of all checks available
-#' g <- gp(path, checks = all_checks()[3:16])
+#' # Run a subset of all checks available
+#' g <- gp(path, checks = all_checks()[9:16])
 #' g
+#' # Or run with named check groups
+#' g <- gp(path, checks = checks_by_group("description", "namespace"))
 
 gp <- function(
   path = ".",

--- a/man/checks.Rd
+++ b/man/checks.Rd
@@ -17,8 +17,11 @@ List all checks performed
 }
 \examples{
 path <- system.file("bad1", package = "goodpractice")
-# run a subset of all checks available
-g <- gp(path, checks = all_checks()[3:16])
+# Run a subset of all checks available
+g <- gp(path, checks = all_checks()[9:16])
+checks(g)
+# Or run with named check groups
+g <- gp(path, checks = checks_by_group("description", "namespace"))
 checks(g)
 }
 \seealso{

--- a/man/failed_checks.Rd
+++ b/man/failed_checks.Rd
@@ -18,7 +18,10 @@ Names of the failed checks
 \examples{
 path <- system.file("bad1", package = "goodpractice")
 # run a subset of all checks available
-g <- gp(path, checks = all_checks()[3:16])
+g <- gp(path, checks = all_checks()[9:16])
+failed_checks(g)
+# Or run with named check groups
+g <- gp(path, checks = checks_by_group("description", "namespace"))
 failed_checks(g)
 }
 \seealso{

--- a/man/gp.Rd
+++ b/man/gp.Rd
@@ -98,7 +98,9 @@ write the same field, the second is dropped with a warning.
 
 \examples{
 path <- system.file("bad1", package = "goodpractice")
-# run a subset of all checks available
-g <- gp(path, checks = all_checks()[3:16])
+# Run a subset of all checks available
+g <- gp(path, checks = all_checks()[9:16])
 g
+# Or run with named check groups
+g <- gp(path, checks = checks_by_group("description", "namespace"))
 }

--- a/man/results.Rd
+++ b/man/results.Rd
@@ -19,8 +19,11 @@ Return all check results in a data frame
 }
 \examples{
 path <- system.file("bad1", package = "goodpractice")
-# run a subset of all checks available
-g <- gp(path, checks = all_checks()[3:16])
+# Run a subset of all checks available
+g <- gp(path, checks = all_checks()[9:16])
+results(g)
+# Or run with named check groups
+g <- gp(path, checks = checks_by_group("description", "namespace"))
 results(g)
 }
 \seealso{


### PR DESCRIPTION
Previous examples of `all_checks()[3:16]` inclued both 'covr' and 'cyclocomp'. This reduces everything down to 'desc' checks only, and extends examples to include check groups.