### PR TITLE
version bump -> dev, post v1.1 CRAN release

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: goodpractice
 Title: Advice on R Package Building
-Version: 1.1.0
+Version: 1.1.0.001
 Authors@R:
     c(
       person(given = "Mark",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -61,7 +61,7 @@ License: MIT + file LICENSE
 URL: https://docs.ropensci.org/goodpractice/, https://github.com/ropensci-review-tools/goodpractice
 BugReports: https://github.com/ropensci-review-tools/goodpractice/issues
 Depends:
-    R (>= 4.0.0)
+    R (>= 4.3.0)
 Imports:
     cli,
     covr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # goodpractice 1.1.00X (dev version)
 
+## Major changes
+
+- Require R version >= 4.3, because of treesitter dependency (#302; thanks to @christian-million)
+
 ## Minor changes
 
 - Fix bug in check group exclusions through env vars, and update vignette.

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## Minor changes
 
 - Fix bug in check group exclusions through env vars, and update vignette.
+- Fix prep assignment to check groups for two checks (revdep + 1 tidyverse)
 
 ---
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 ## Minor changes
 
 - Fix bug in check group exclusions through env vars, and update vignette.
-- Fix prep assignment to check groups for two checks (revdep + 1 tidyverse)
+- Fix prep assignment to check groups for two checks (revdep + 1 tidyverse), including attaching "namespace" prep only internally to one of those so full tidyverse prep stage is only run for that group.
 
 ---
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# goodpractice 1.1.00X (dev version)
+
+## Minor changes
+
+- Fix bug in check group exclusions through env vars, and update vignette.
+
+---
+
 # goodpractice 1.1
 
 ## 1. Check control and output

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,96 +1,84 @@
-# goodpractice 1.0.5.9000 (dev version)
+# goodpractice 1.1
 
-- Added new `describe_check_groups()` function, to produce group descriptions
-  in console (#290).
-- Added 'groups' param to `print()` method, to enable printing only specified
-  groups (#288).
-* New `lintr_installed_packages_linter` check: flags calls to `installed.packages()`,
-  which can be very slow and is rejected by CRAN. Use `find.package()` or
-  `system.file()` instead (#278).
-* Tree-sitter function detection now only considers assignment operators
-  (`<-`, `=`, `<<-`), avoiding false matches on arithmetic expressions
-  such as `x + function() 1` (#277).
-* `ts_parse()` now honours the package's declared `Encoding` when reading
-  source files, preventing mojibake for packages using non-UTF-8 encodings.
-  `prep_description` defaults `Encoding` to `UTF-8` when absent, so
-  downstream checks always have a concrete value. Unreadable files emit a
-  warning instead of being silently skipped (#277).
-* Added `makefile` (#203)
-* Lowered default cyclomatic complexity limit from 50 to 15, aligning
-  with lintr and pkgcheck defaults. Configurable via
-  `goodpractice.cyclocomp_limit` option (#150).
-* Expanded default lintr checks from 9 to ~53, covering correctness
-  (e.g. `anyDuplicated()` vs `any(duplicated())`), performance
-  (e.g. `colSums()` vs `apply()`), readability (e.g. `switch()` vs
-  long if/else chains), and testthat best practices (e.g.
-  `expect_identical()` vs `expect_equal()`). All respect `.lintr`
-  configuration files (#189).
-* Exclude specific files from checks via `goodpractice.exclude_path` option
-  or `GP_EXCLUDE_PATH` environment variable. Useful for generated code like
-  `R/RcppExports.R`.
-* Preparation steps can now run in parallel via the `future.apply` package.
-  Set `future::plan("multisession")` before calling `gp()` to enable
-  parallel data gathering (#47).
-* New `all_check_groups()` and `checks_by_group()` functions for discovering
-  and selecting checks by category instead of individual names (#239).
-* Every check now belongs to a named group. Use `all_check_groups()` to see
-  the 16 available groups and `checks_by_group("description")` to list checks
-  in a group.
-* Exclude entire check groups via `goodpractice.exclude_check_groups` option
-  or `GP_EXCLUDE_CHECK_GROUPS` environment variable.
-* New roxygen2 checks: export/noRd tagging, unknown tags, and
-  `@inheritParams`/`@inheritDotParams` validation (#197).
-* New `duplicate_function_bodies` check: flags functions with identical bodies
-  across files that should be consolidated into a shared helper (#232).
-* Check advice now uses cli inline markup throughout. All `gp` strings support
-  `{.code}`, `{.fn}`, `{.pkg}`, `{.file}`, `{.field}`, and `{.url}` for
-  consistent styling. Custom checks can use the same markup in their `gp`
-  strings.
-* New optional tidyverse style guide checks: 21 lintr-based checks plus 2
-  structural checks (R file naming, test file mirroring).
-  Opt in via `checks = c(default_checks(), tidyverse_checks())`.
+## 1. Check control and output
+
+### 1.1 Check groups
+
+* New `all_check_groups()` and `checks_by_group()` functions for discovering and selecting checks by category instead of individual names (#239).
+* Every check now belongs to a named group. Use `all_check_groups()` to see the 16 available groups and `checks_by_group("description")` to list checks in a group.
+* Added new `describe_check_groups()` function, to produce group descriptions in console (#290).
+* Added 'groups' param to `print()` method, to enable printing only specified groups (#288).
+* Exclude entire check groups via `goodpractice.exclude_check_groups` option or `GP_EXCLUDE_CHECK_GROUPS` environment variable.
+
+### 1.2 Default checks and check control
+
 * New `default_checks()` and `tidyverse_checks()` helper functions.
-  `gp()` now defaults to `default_checks()` instead of `all_checks()`,
-  keeping optional check sets out of the default run.
-* New `has_readme` and `has_news` checks for package documentation
-  completeness (#45).
-* `gp()` now fails if the path provided to it is not a package (does not contain a
-  DESCRIPTION file) (#190, @maelle)
-* goodpractice now uses cli, and no longer depends on crayon and clisymbols (@olivroy, #167).
-* If your editor supports it, goodpractice now prints clickable hyperlinks to console.
+* `gp()` now defaults to `default_checks()` instead of `all_checks()`, keeping optional check sets out of the default run.
 * New `describe_check()` function to print descriptions of all implemented checks (@152)
+* Exclude specific files from checks via `goodpractice.exclude_path` option or `GP_EXCLUDE_PATH` environment variable. Useful for generated code like `R/RcppExports.R`.
+
+### 1.3 Screen output
+
+* goodpractice now uses cli, and no longer depends on crayon and clisymbols (@olivroy, #167).
+* Check advice now uses cli inline markup throughout. All `gp` strings support `{.code}`, `{.fn}`, `{.pkg}`, `{.file}`, `{.field}`, and `{.url}` for consistent styling. Custom checks can use the same markup in their `gp` strings.
+* If your editor supports it, goodpractice now prints clickable hyperlinks to console.
+* `gp_advice()` gains a `type` parameter (`"error"`, `"info"`, `"warning"`) to control the output symbol and colour. Checks can return `list(status = TRUE, type = "info")` to display informational messages without a failure cross.
+
+---
+
+## 2. treesitter
+
+* R code inspection now uses treesitter for AST-based parsing instead of regex or `getParseData()`. Checks like `print_return_invisible`, `tidyverse_no_missing`, and `tidyverse_export_order` benefit from more robust and faster code analysis.
+* Tree-sitter function detection now only considers assignment operators (`<-`, `=`, `<<-`), avoiding false matches on arithmetic expressions such as `x + function() 1` (#277).
+* `ts_parse()` now honours the package's declared `Encoding` when reading source files, preventing mojibake for packages using non-UTF-8 encodings.
+* New `duplicate_function_bodies` check: flags functions with identical bodies across files that should be consolidated into a shared helper (#232).
+
+---
+
+## 3. New checks
+
+### 3.1 New linters
+
+* Expanded default lintr checks from 9 to ~53, covering correctness (e.g. `anyDuplicated()` vs `any(duplicated())`), performance (e.g. `colSums()` vs `apply()`), readability (e.g. `switch()` vs long if/else chains), and testthat best practices (e.g. `expect_identical()` vs `expect_equal()`). All respect `.lintr` configuration files (#189).
+* New `lintr_installed_packages_linter` check: flags calls to `installed.packages()`,
+  which can be very slow and is rejected by CRAN. Use `find.package()` or `system.file()` instead (#278).
+* New optional tidyverse style guide checks: 21 lintr-based checks plus 2 structural checks (R file naming, test file mirroring). Opt in via `checks = c(default_checks(), tidyverse_checks())`.
+
+### 3.2 New DESCRIPTION checks
+
+* `prep_description` defaults `Encoding` to `UTF-8` when absent, so downstream checks always have a concrete value. Unreadable files emit a warning instead of being silently skipped (#277).
+* New DESCRIPTION checks (#122, #85):
+  - `description_not_start_with_package`: Description should not start with "This package"
+  - `description_urls_in_angle_brackets`: URLs in Description must be wrapped in angle brackets
+  - `description_doi_format`: DOIs should use `<doi:...>` not full URLs
+  - `description_urls_not_http`: URLs should use https not http
+  - `no_description_duplicate_deps`: No duplicate packages across dependency fields
+  - `description_valid_roles`: Authors@R roles must be valid MARC relator codes
+  - `description_pkgname_single_quoted`: Package names in Title/Description must be single-quoted
+
+### 3.3 Other new checks
+
 * New `r_file_extension` check: flags R scripts using `.r` or `.q` instead of `.R` (#121).
 * New `print_return_invisible` check: flags print methods that don't return `invisible(x)` (#49).
 * New `vignette_no_rm_list` check: flags `rm(list = ls())` in vignettes (#20).
 * New `vignette_no_setwd` check: flags `setwd()` in vignettes (#21).
-* R code inspection now uses treesitter for AST-based parsing instead of
-  regex or `getParseData()`. Checks like `print_return_invisible`,
-  `tidyverse_no_missing`, and `tidyverse_export_order` benefit from more
-  robust and faster code analysis.
-* New `reverse_dependencies` check: queries CRAN for reverse dependencies and advises
-  running `revdepcheck::revdep_check()` before submission.
-* `gp_advice()` gains a `type` parameter (`"error"`, `"info"`, `"warning"`) to
-  control the output symbol and colour. Checks can return
-  `list(status = TRUE, type = "info")` to display informational messages
-  without a failure cross.
-* Prep step error handling refactored into `run_prep_step()` helper. New prep
-  functions can use `run_prep_step(state, "name", function() { ... }, quiet)`
-  instead of manually wrapping work in `try()` and emitting warnings on failure.
+* New `reverse_dependencies` check: queries CRAN for reverse dependencies and advises running `revdepcheck::revdep_check()` before submission.
 * New `spelling` check: flags misspelled words in documentation via `spelling::spell_check_package()` (#84).
-* New DESCRIPTION checks (#122, #85):
-  - `description_not_start_with_package`: Description should not start with
-    "This package"
-  - `description_urls_in_angle_brackets`: URLs in Description must be wrapped
-    in angle brackets
-  - `description_doi_format`: DOIs should use `<doi:...>` not full URLs
-  - `description_urls_not_http`: URLs should use https not http
-  - `no_description_duplicate_deps`: No duplicate packages across dependency
-    fields
-  - `description_valid_roles`: Authors@R roles must be valid MARC relator codes
-  - `description_pkgname_single_quoted`: Package names in Title/Description
-    must be single-quoted
-* Removed `stringsAsFactors = FALSE` arguments throughout, relying on the
-  R 4.0 default. Package now requires R >= 4.0.0.
+* New `has_readme` and `has_news` checks for package documentation completeness (#45).
+* New roxygen2 checks: export/noRd tagging, unknown tags, and `@inheritParams`/`@inheritDotParams` validation (#197).
+
+---
+
+## 4. Other updates
+
+* Added `makefile` (#203)
+* Lowered default cyclomatic complexity limit from 50 to 15, aligning with lintr and pkgcheck defaults. Configurable via `goodpractice.cyclocomp_limit` option (#150).
+* Preparation steps can now run in parallel via the `future.apply` package. Set `future::plan("multisession")` before calling `gp()` to enable parallel data gathering (#47).
+* `gp()` now fails if the path provided to it is not a package (does not contain a DESCRIPTION file) (#190, @maelle)
+* Prep step error handling refactored into `run_prep_step()` helper. New prep functions can use `run_prep_step(state, "name", function() { ... }, quiet)` instead of manually wrapping work in `try()` and emitting warnings on failure.
+* Removed `stringsAsFactors = FALSE` arguments throughout, relying on the R 4.0 default. Package now requires R >= 4.0.0.
+
+----
 
 # goodpractice 1.0.5
 

--- a/R/chk_revdep.R
+++ b/R/chk_revdep.R
@@ -23,7 +23,7 @@ CHECKS$reverse_dependencies <- make_check(
 
   description = "Check for reverse dependencies on CRAN",
   tags = c("info", "CRAN"),
-  preps = c("description", "revdep"),
+  preps = "revdep",
 
   gp = function(state) {
     revdeps <- state$checks$reverse_dependencies$revdeps

--- a/R/chk_revdep.R
+++ b/R/chk_revdep.R
@@ -23,7 +23,7 @@ CHECKS$reverse_dependencies <- make_check(
 
   description = "Check for reverse dependencies on CRAN",
   tags = c("info", "CRAN"),
-  preps = "revdep",
+  preps = c("description", "revdep"),
 
   gp = function(state) {
     revdeps <- state$checks$reverse_dependencies$revdeps

--- a/R/chk_tidyverse.R
+++ b/R/chk_tidyverse.R
@@ -559,17 +559,18 @@ CHECKS$tidyverse_export_order <- make_check(
 
   description = "Exported functions are defined before internal helpers",
   tags = c("style", "tidyverse"),
-  preps = c("namespace", "tidyverse"),
+  preps = "tidyverse",
 
   gp = "define exported (user-facing) functions before internal
         helper functions within each R source file.",
 
   check = function(state) {
-    if (inherits(state$namespace, "try-error")) {
+    path <- normalizePath(state$path)
+    ns <- try(parseNamespaceFile(basename(path), dirname(path)), silent = TRUE)
+    if (inherits(ns, "try-error")) {
       return(na_result())
     }
 
-    ns <- state$namespace
     exported <- c(ns$exports, ns_s3_method_names(ns))
 
     patterns <- ns$exportPatterns

--- a/R/chk_tidyverse.R
+++ b/R/chk_tidyverse.R
@@ -559,7 +559,7 @@ CHECKS$tidyverse_export_order <- make_check(
 
   description = "Exported functions are defined before internal helpers",
   tags = c("style", "tidyverse"),
-  preps = c("namespace", "tidyverse"),
+  preps = "tidyverse",
 
   gp = "define exported (user-facing) functions before internal
         helper functions within each R source file.",

--- a/R/chk_tidyverse.R
+++ b/R/chk_tidyverse.R
@@ -559,7 +559,7 @@ CHECKS$tidyverse_export_order <- make_check(
 
   description = "Exported functions are defined before internal helpers",
   tags = c("style", "tidyverse"),
-  preps = "tidyverse",
+  preps = c("namespace", "tidyverse"),
 
   gp = "define exported (user-facing) functions before internal
         helper functions within each R source file.",

--- a/R/gp.R
+++ b/R/gp.R
@@ -119,11 +119,10 @@ validate_pkg_path <- function(path) {
 }
 
 resolve_checks <- function(checks, mychecks) {
-  if (is.null(checks)) {
-    exclude_checks_by_group(names(mychecks), mychecks)
-  } else {
-    checks
+  if (identical(checks, default_checks())) {
+    checks <- exclude_checks_by_group(checks, mychecks)
   }
+  checks
 }
 
 required_preps <- function(checks, mychecks) {
@@ -219,7 +218,7 @@ exclude_checks_by_group <- function(checks, mychecks) {
   }, logical(1))
 
   if (any(dominated)) {
-    cli::cli_warn("Excluding checks that depend on: {.val {exclude}}")
+    cli::cli_alert_info("Excluding checks that depend on: {.val {exclude}}")
   }
   checks[!dominated]
 }

--- a/codemeta.json
+++ b/codemeta.json
@@ -4,20 +4,17 @@
   "identifier": "goodpractice",
   "description": "Give advice about good practices when building R packages. Advice includes functions and syntax to avoid, package structure, code complexity, code formatting, etc.",
   "name": "goodpractice: Advice on R Package Building",
-  "relatedLink": [
-    "https://docs.ropensci.org/goodpractice/",
-    "https://CRAN.R-project.org/package=goodpractice"
-  ],
+  "relatedLink": ["https://docs.ropensci.org/goodpractice/", "https://CRAN.R-project.org/package=goodpractice"],
   "codeRepository": "https://github.com/ropensci-review-tools/goodpractice",
   "issueTracker": "https://github.com/ropensci-review-tools/goodpractice/issues",
   "license": "https://spdx.org/licenses/MIT",
-  "version": "1.1.0.001",
+  "version": "1.1.0.1",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",
     "url": "https://r-project.org"
   },
-  "runtimePlatform": "R version 4.4.1 (2024-06-14)",
+  "runtimePlatform": "R version 4.6.0 (2026-04-24)",
   "provider": {
     "@id": "https://cran.r-project.org",
     "@type": "Organization",
@@ -66,6 +63,13 @@
       "givenName": "Hannah",
       "familyName": "Alexander",
       "email": "halexander@mango-solutions.com"
+    },
+    {
+      "@type": "Person",
+      "givenName": "Athanasia Mo",
+      "familyName": "Mowinckel",
+      "email": "a.m.mowinckel@psykologi.uio.no",
+      "@id": "https://orcid.org/0000-0002-5756-0223"
     }
   ],
   "contributor": [
@@ -97,6 +101,42 @@
     }
   ],
   "softwareSuggestions": [
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "future",
+      "name": "future",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=future"
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "future.apply",
+      "name": "future.apply",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=future.apply"
+    },
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "kableExtra",
+      "name": "kableExtra",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=kableExtra"
+    },
     {
       "@type": "SoftwareApplication",
       "identifier": "knitr",
@@ -138,6 +178,12 @@
   "softwareRequirements": {
     "1": {
       "@type": "SoftwareApplication",
+      "identifier": "R",
+      "name": "R",
+      "version": ">= 4.3.0"
+    },
+    "2": {
+      "@type": "SoftwareApplication",
       "identifier": "cli",
       "name": "cli",
       "provider": {
@@ -148,7 +194,7 @@
       },
       "sameAs": "https://CRAN.R-project.org/package=cli"
     },
-    "2": {
+    "3": {
       "@type": "SoftwareApplication",
       "identifier": "covr",
       "name": "covr",
@@ -160,7 +206,19 @@
       },
       "sameAs": "https://CRAN.R-project.org/package=covr"
     },
-    "3": {
+    "4": {
+      "@type": "SoftwareApplication",
+      "identifier": "curl",
+      "name": "curl",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=curl"
+    },
+    "5": {
       "@type": "SoftwareApplication",
       "identifier": "cyclocomp",
       "name": "cyclocomp",
@@ -173,7 +231,7 @@
       },
       "sameAs": "https://CRAN.R-project.org/package=cyclocomp"
     },
-    "4": {
+    "6": {
       "@type": "SoftwareApplication",
       "identifier": "desc",
       "name": "desc",
@@ -185,7 +243,7 @@
       },
       "sameAs": "https://CRAN.R-project.org/package=desc"
     },
-    "5": {
+    "7": {
       "@type": "SoftwareApplication",
       "identifier": "jsonlite",
       "name": "jsonlite",
@@ -197,7 +255,7 @@
       },
       "sameAs": "https://CRAN.R-project.org/package=jsonlite"
     },
-    "6": {
+    "8": {
       "@type": "SoftwareApplication",
       "identifier": "lintr",
       "name": "lintr",
@@ -210,7 +268,7 @@
       },
       "sameAs": "https://CRAN.R-project.org/package=lintr"
     },
-    "7": {
+    "9": {
       "@type": "SoftwareApplication",
       "identifier": "praise",
       "name": "praise",
@@ -222,7 +280,7 @@
       },
       "sameAs": "https://CRAN.R-project.org/package=praise"
     },
-    "8": {
+    "10": {
       "@type": "SoftwareApplication",
       "identifier": "rcmdcheck",
       "name": "rcmdcheck",
@@ -234,7 +292,19 @@
       },
       "sameAs": "https://CRAN.R-project.org/package=rcmdcheck"
     },
-    "9": {
+    "11": {
+      "@type": "SoftwareApplication",
+      "identifier": "roxygen2",
+      "name": "roxygen2",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=roxygen2"
+    },
+    "12": {
       "@type": "SoftwareApplication",
       "identifier": "rstudioapi",
       "name": "rstudioapi",
@@ -246,17 +316,65 @@
       },
       "sameAs": "https://CRAN.R-project.org/package=rstudioapi"
     },
-    "10": {
+    "13": {
+      "@type": "SoftwareApplication",
+      "identifier": "spelling",
+      "name": "spelling",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=spelling"
+    },
+    "14": {
       "@type": "SoftwareApplication",
       "identifier": "tools",
       "name": "tools"
     },
-    "11": {
+    "15": {
+      "@type": "SoftwareApplication",
+      "identifier": "treesitter",
+      "name": "treesitter",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=treesitter"
+    },
+    "16": {
+      "@type": "SoftwareApplication",
+      "identifier": "treesitter.r",
+      "name": "treesitter.r",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=treesitter.r"
+    },
+    "17": {
+      "@type": "SoftwareApplication",
+      "identifier": "urlchecker",
+      "name": "urlchecker",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=urlchecker"
+    },
+    "18": {
       "@type": "SoftwareApplication",
       "identifier": "utils",
       "name": "utils"
     },
-    "12": {
+    "19": {
       "@type": "SoftwareApplication",
       "identifier": "whoami",
       "name": "whoami",
@@ -268,7 +386,7 @@
       },
       "sameAs": "https://CRAN.R-project.org/package=whoami"
     },
-    "13": {
+    "20": {
       "@type": "SoftwareApplication",
       "identifier": "withr",
       "name": "withr",
@@ -280,13 +398,10 @@
       },
       "sameAs": "https://CRAN.R-project.org/package=withr"
     },
-    "SystemRequirements": {}
+    "SystemRequirements": null
   },
-  "fileSize": "151.202KB",
-  "releaseNotes": "https://github.com/ropensci-review-tools/goodpractice/blob/master/NEWS.md",
+  "fileSize": "463.491KB",
+  "releaseNotes": "https://github.com/ropensci-review-tools/goodpractice/blob/main/NEWS.md",
   "readme": "https://github.com/ropensci-review-tools/goodpractice/blob/main/README.md",
-  "contIntegration": [
-    "https://github.com/ropensci-review-tools/goodpractice/actions",
-    "https://app.codecov.io/gh/ropensci-review-tools/goodpractice?branch=main"
-  ]
+  "contIntegration": ["https://github.com/ropensci-review-tools/goodpractice/actions", "https://app.codecov.io/gh/ropensci-review-tools/goodpractice?branch=main"]
 }

--- a/codemeta.json
+++ b/codemeta.json
@@ -11,7 +11,7 @@
   "codeRepository": "https://github.com/ropensci-review-tools/goodpractice",
   "issueTracker": "https://github.com/ropensci-review-tools/goodpractice/issues",
   "license": "https://spdx.org/licenses/MIT",
-  "version": "1.0.5.9001",
+  "version": "1.1.0.001",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",

--- a/tests/testthat/bad_tidyverse/.lintr
+++ b/tests/testthat/bad_tidyverse/.lintr
@@ -1,0 +1,1 @@
+linters: linters_with_defaults()

--- a/tests/testthat/good_tidyverse/.lintr
+++ b/tests/testthat/good_tidyverse/.lintr
@@ -1,0 +1,1 @@
+linters: linters_with_defaults()

--- a/tests/testthat/test-check-selection.R
+++ b/tests/testthat/test-check-selection.R
@@ -76,11 +76,9 @@ test_that("all check groups map to registered preps", {
 test_that("checks with multiple groups are known", {
   lens <- vapply(CHECKS, function(ch) length(ch$preps), integer(1L))
   multi <- names(lens[lens >= 2])
-  expect_gte(length(multi), 3)
+  expect_gte(length(multi), 2)
   expect_true("rd_has_examples" %in% multi)
   expect_true("rd_has_return" %in% multi)
-  expect_true("reverse_dependencies" %in% multi)
-  expect_true("tidyverse_export_order" %in% multi)
 })
 
 test_that("all tidyverse checks belong to the tidyverse group", {

--- a/tests/testthat/test-gp.R
+++ b/tests/testthat/test-gp.R
@@ -110,55 +110,38 @@ test_that("check_failed is the inverse of check_passed", {
 
 test_that("option excludes checks by group name", {
   bad1 <- system.file("bad1", package = "goodpractice")
-  withr::local_options(goodpractice.exclude_check_groups = "covr")
-  expect_warning(
-    gp_res <- gp(bad1, checks = NULL),
-    "Excluding checks"
-  )
-  expect_false("covr" %in% checks(gp_res))
+  excl <- c("covr", "rcmdcheck", "cyclocomp")
+  withr::local_options(goodpractice.exclude_check_groups = excl)
+  gp_res <- gp(bad1)
+  ptn <- paste0("^(", paste0(excl, collapse = "|"), ")")
+  expect_false(any(grepl(ptn, checks(gp_res))))
 })
 
 test_that("envvar excludes checks by group name", {
   bad1 <- system.file("bad1", package = "goodpractice")
   withr::local_options(goodpractice.exclude_check_groups = NULL)
-  withr::local_envvar(GP_EXCLUDE_CHECK_GROUPS = "covr")
-  expect_warning(
-    gp_res <- gp(bad1, checks = NULL),
-    "Excluding checks"
-  )
-  expect_false("covr" %in% checks(gp_res))
+  excl <- c("covr", "rcmdcheck", "cyclocomp")
+  withr::local_envvar(GP_EXCLUDE_CHECK_GROUPS = paste0(excl,collapse=","))
+  gp_res <- gp(bad1)
+  ptn <- paste0("^(", paste0(excl, collapse = "|"), ")")
+  expect_false(any(grepl(ptn, checks(gp_res))))
 })
 
 test_that("option takes precedence over envvar", {
   bad1 <- system.file("bad1", package = "goodpractice")
-  withr::local_options(goodpractice.exclude_check_groups = "covr")
+  withr::local_options(goodpractice.exclude_check_groups = c("covr", "cyclocomp", "rcmdcheck"))
   withr::local_envvar(GP_EXCLUDE_CHECK_GROUPS = "lintr")
-  expect_warning(
-    gp_res <- gp(bad1, checks = NULL),
-    "Excluding checks"
-  )
+  gp_res <- gp(bad1)
   expect_false("covr" %in% checks(gp_res))
+  expect_false("cyclocomp" %in% checks(gp_res))
   expect_true(any(grepl("^lintr_", checks(gp_res))))
 })
 
-test_that("explicit checks argument overrides exclusion", {
+test_that("non-default checks argument overrides exclusion", {
   bad1 <- system.file("bad1", package = "goodpractice")
   withr::local_options(goodpractice.exclude_check_groups = "description")
   gp_res <- gp(bad1, checks = "no_description_depends")
   expect_true("no_description_depends" %in% checks(gp_res))
-})
-
-test_that("multiple groups can be excluded", {
-  bad1 <- system.file("bad1", package = "goodpractice")
-  withr::local_options(
-    goodpractice.exclude_check_groups = c("covr", "cyclocomp")
-  )
-  expect_warning(
-    gp_res <- gp(bad1, checks = NULL),
-    "Excluding checks"
-  )
-  expect_false("covr" %in% checks(gp_res))
-  expect_false("cyclocomp" %in% checks(gp_res))
 })
 
 test_that("empty exclusion returns checks unchanged", {

--- a/vignettes/goodpractice.Rmd
+++ b/vignettes/goodpractice.Rmd
@@ -173,10 +173,10 @@ gp(".")
 
 Every check that depends on a skipped group is automatically excluded too.
 
-For CI/CD pipelines, you can set this via the `GP_EXCLUDE_CHECK_GROUPS` environment variable instead of modifying R code:
+For CI/CD pipelines, you can exclude check groups by specifying them in comma-separate format via the `GP_EXCLUDE_CHECK_GROUPS` environment variable:
 
 ```bash
-GP_EXCLUDE_CHECK_GROUPS=covr,rcmdcheck Rscript -e 'goodpractice::gp(".")'
+GP_EXCLUDE_CHECK_GROUPS='covr,lintr,rcmdcheck'
 ```
 
 When both the R option and the environment variable are set, the R option wins.


### PR DESCRIPTION
- Restructure NEWS.md to make more human readable
- Fix a bug in check exclusion groups that were previously only picked up with explicit `gp(checks = NULL)` calls, but otherwise not at all via default `gp()` with non-null `checks` param.
- Also updates vignette to better explain group exclusion by env var.
- Downgrades check group skip from warning to `cli_alert_info()`, because otherwise any CI jobs which auto-skip groups via options or envvars would trigger warnings and thus likely failures, which is not good at all. That also required updating tests, including removal of one redundant test.
- One tidyverse check used to drag in "namespace" prep group, but that meant any checks which used that also triggered tidyverse prep. And that in turn meant that most check runs produced this message:
    > :heavy_check_mark: Prepared tidyverse

    and that was very confusing, as that's supposed to be opt-in only, but I could never switch it off. This fixes that.