### PR TITLE
Invalid marker type

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 
 - Fix bug in check group exclusions through env vars, and update vignette.
 - Fix prep assignment to check groups for two checks (revdep + 1 tidyverse), including attaching "namespace" prep only internally to one of those so full tidyverse prep stage is only run for that group.
+- Fix bug in printing some check results that would produce an error caused by invalid marker types (#304; thanks to @JesseAlderliesten).
 
 ---
 

--- a/R/chk_rd.R
+++ b/R/chk_rd.R
@@ -44,7 +44,7 @@ make_rd_check <- function(description, gp, field, tags = NULL,
                           skip_internal = FALSE) {
   make_check(
     description = description,
-    tags = c("documentation", tags),
+    tags = c("style", "documentation", tags),
     preps = c("rd", "namespace"),
     gp = gp,
     check = function(state) rd_check_field(state, field, skip_internal)

--- a/R/chk_roxygen2.R
+++ b/R/chk_roxygen2.R
@@ -27,7 +27,7 @@ make_block_position <- function(block) {
 CHECKS$roxygen2_has_export_or_nord <- make_check(
 
   description = "Documented functions have @export, @noRd, or @rdname",
-  tags = c("documentation", "roxygen2"),
+  tags = c("style", "documentation", "roxygen2"),
   preps = "roxygen2",
   gp = paste(
     "Tag every documented function with either {.code @export},",
@@ -66,7 +66,7 @@ CHECKS$roxygen2_has_export_or_nord <- make_check(
 CHECKS$roxygen2_unknown_tags <- make_check(
 
   description = "All roxygen2 tags are recognized",
-  tags = c("documentation", "roxygen2"),
+  tags = c("style", "documentation", "roxygen2"),
   preps = "roxygen2",
   gp = paste(
     "Fix or remove unknown {.pkg roxygen2} tags.",
@@ -107,7 +107,7 @@ CHECKS$roxygen2_unknown_tags <- make_check(
 CHECKS$roxygen2_valid_inherit <- make_check(
 
   description = "@inheritParams/@inheritDotParams reference known functions",
-  tags = c("documentation", "roxygen2"),
+  tags = c("style", "documentation", "roxygen2"),
   preps = "roxygen2",
   gp = paste(
     "Ensure functions referenced by",
@@ -163,7 +163,7 @@ extract_block_params <- function(block) {
 CHECKS$roxygen2_duplicate_params <- make_check(
 
   description = "Avoid duplicated @param documentation across functions",
-  tags = c("documentation", "roxygen2"),
+  tags = c("style", "documentation", "roxygen2"),
   preps = "roxygen2",
 
   gp = paste(

--- a/R/chk_urlchecker.R
+++ b/R/chk_urlchecker.R
@@ -13,7 +13,7 @@ urlchecker_make_positions <- function(db) {
 make_urlchecker_check <- function(description, gp, filter, tags = NULL) {
   make_check(
     description = description,
-    tags = c("documentation", "url", tags),
+    tags = c("style", "documentation", "url", tags),
     preps = "urlchecker",
     gp = gp,
 


### PR DESCRIPTION
## Problem
To get a reproducible example, I modified code the README of package `pkgcheck` (https://github.com/ropensci-review-tools/pkgcheck):

```{r}
mydir <- file.path (tempdir (), "srr-demo")
gert::git_clone ("https://github.com/mpadge/srr-demo", path = mydir)
devtools::document (mydir, quiet = TRUE)
x <- goodpractice::gp(path = mydir, checks = c("rd_has_examples", "rd_has_return"))
summary(x) # Fine: finds various problems without throwing an error
print(x) # gives error
```
This gives an error: for `rstudio` versions earlier than 2026.05.0 the cryptic error:
```
Error in if (is.null(marker$type) || (!marker$type %in% markerTypes))
stop("Invalid marker type (",  : missing value where TRUE/FALSE needed
```
and for `rstudio` versions 2026.05.0 and later the more informative error: `Invalid marker type`.

## Cause of the error
The error is produced for `goodpractice`-objects with elements where the `tags` do not contain at least one of `("error", "warning", "info", "style", "usage")`: if a test fails, `print.goodpractice(x)` passes the tags to argument `type` of `rstudio::sourceMarkers(x)`, which requires it to be one of the indicated `tags` (see `Details` in `help("sourceMarkers", package = "rstudioapi")`).

The code above leads to this error because the checks `"rd_has_examples"` and `"rd_has_return"` only have the tag `documentation`. These tags are neglected by `get_marker()` because they are not allowed by `rstudio::sourceMarkers(x)`, leaving `character(0)` as tag.

## Fix by this PR
The pull request fixes this for the specific cases where I encountered it, by adding add `style` to the default `tags` inside the calls to `make_*_check()` and `make_check()` (for all `CHECKS$roxygen2_*`):

- check_rd.R: make_rd_check
- chk_urlchecker.R: make_urlchecker_check
- R/chk_roxygen2.R: all `CHECKS$roxygen2_*`

## Further ideas
I am not sure about `R/chk_rcmdcheck.R`, which seems to do something special, so I did not change that file.

To fix this in a more robust way, the selection of markers in `goodpractice::get_marker()` (in file `rstudio_markers.R`) would have to be changed to choose a sensible `type` if none of the markers is one of c("error", "warning", "info", "style", "usage"), also if it is zero-length.

Specifically, this piece of code needs to be adjusted:

```
type <- head(intersect(
  chk$tags,
  c("error", "warning", "info", "style", "usage")
), 1)
```

I have **not** done that in this PR because I do not know what fall-back option to use as sensible default.