### PR TITLE
Fixes for goodpractice4agents skill (#312 follow-up)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## Major changes
 
 - Require R version >= 4.3, because of treesitter dependency (#302; thanks to @christian-million)
+- New `write_gp4agents()` and `learn_gp_skill()` functions, plus a bundled `goodpractice4agents.md` skill in `inst/skills/`, giving AI agents instructions to fix issues flagged by `goodpractice` (#308, #312; thanks to @mpadge and @jonthegeek).
 
 ## Minor changes
 
@@ -10,6 +11,7 @@
 - Fix bug in check group exclusions through env vars, and update vignette.
 - Fix prep assignment to check groups for two checks (revdep + 1 tidyverse), including attaching "namespace" prep only internally to one of those so full tidyverse prep stage is only run for that group.
 - Fix bug in printing some check results that would produce an error caused by invalid marker types (#304; thanks to @JesseAlderliesten).
+- `export_json()` no longer errors ("attempt to apply non-function") when called on a `gp` result whose checks do not include the `description` group; the package name is now read from the always-populated `gp$package` field.
 
 ---
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 ## Major changes
 
 - Require R version >= 4.3, because of treesitter dependency (#302; thanks to @christian-million)
-- New `write_gp4agents()` and `learn_gp_skill()` functions, plus a bundled `goodpractice4agents.md` skill in `inst/skills/`, giving AI agents instructions to fix issues flagged by `goodpractice` (#308, #312; thanks to @mpadge and @jonthegeek).
+- New `write_gp4agents()` and `learn_gp_skill()` functions, plus a bundled `goodpractice4agents.md` skill in `inst/skills/`, giving AI agents instructions to fix issues flagged by `goodpractice` (#308, #312, #313; thanks to @mpadge, @drmowinckels, and @jonthegeek).
 
 ## Minor changes
 

--- a/R/api.R
+++ b/R/api.R
@@ -115,7 +115,7 @@ get_position <- function(chk) {
 export_json <- function(gp, file, pretty = FALSE) {
 
   obj <- list(
-    package = gp$description$get("Package"),
+    package = gp$package,
     path = gp$path,
     failures = Filter(check_failed, gp$checks),
     gp_version = loaded_pkg_version("goodpractice"),
@@ -132,7 +132,7 @@ export_json <- function(gp, file, pretty = FALSE) {
 #' use this package.
 #'
 #' The 'goodpractice4agents.md' file contains sufficient instructions for most
-#' AI %agents to edit package code so that it passes most 'goodpractice'
+#' AI agents to edit package code so that it passes most 'goodpractice'
 #' checks. The file can be directly edited and tweaked for personal use cases.
 #' An agent can be instructed to simply "run the file goodpractice4agents.md".
 #' The file can also be moved to any local agent's \code{skills/} directory to
@@ -140,42 +140,45 @@ export_json <- function(gp, file, pretty = FALSE) {
 #' downloaded from GitHub at
 #' \url{https://github.com/ropensci-review-tools/goodpractice/tree/main/inst/skills/goodpractice4agents.md}.
 #'
-#' @param path Local path where file should be extracted.
-#' @return (Invisibly) Full path to file.
-#' \code{FALSE}.
+#' @param path Local path where the file should be written. If \code{path} is
+#' an existing directory, the file is written as \code{goodpractice4agents.md}
+#' within it; otherwise \code{path} is treated as the full target file name.
+#' @return (Invisibly) the full path to the written file.
 #'
 #' @export
 #' @examples
 #' path <- file.path(tempdir(), "skill.md")
 #' f <- write_gp4agents(path)
 #' file.exists(f)
+#' unlink(f)
 
 write_gp4agents <- function(path = ".") {
-    if (file.exists(path)) {
-        stop("File ", path, " already exists.", call. = FALSE)
-    }
     if (dir.exists(path)) {
         path <- file.path(path, "goodpractice4agents.md")
-    } else {
-        if (!dir.exists(dirname(path))) {
-            stop(
-                "Directory ",
-                basename(path),
-                " does not exist.",
-                call. = FALSE
-            )
-        }
+    } else if (!dir.exists(dirname(path))) {
+        stop(
+            "Directory ",
+            dirname(path),
+            " does not exist.",
+            call. = FALSE
+        )
+    }
+
+    if (file.exists(path)) {
+        stop("File ", path, " already exists.", call. = FALSE)
     }
 
     src <- system.file(
         "skills", "goodpractice4agents.md", package = "goodpractice"
     )
     if (!file.exists(src)) {
-        stop("Expected error: File ", src, " not found.", .call = FALSE)
+        stop("File ", src, " not found.", call. = FALSE)
     }
-    file.copy(src, path)
+    if (!file.copy(src, path)) {
+        stop("Failed to copy file to ", path, ".", call. = FALSE)
+    }
 
-    return(path)
+    invisible(path)
 }
 
 #' Function for AI agents to run and learn how to use the 'goodpractice'

--- a/R/api.R
+++ b/R/api.R
@@ -156,26 +156,21 @@ write_gp4agents <- function(path = ".") {
     if (dir.exists(path)) {
         path <- file.path(path, "goodpractice4agents.md")
     } else if (!dir.exists(dirname(path))) {
-        stop(
-            "Directory ",
-            dirname(path),
-            " does not exist.",
-            call. = FALSE
-        )
+        cli::cli_abort("Directory {.path {dirname(path)}} does not exist.")
     }
 
     if (file.exists(path)) {
-        stop("File ", path, " already exists.", call. = FALSE)
+        cli::cli_abort("File {.file {path}} already exists.")
     }
 
     src <- system.file(
         "skills", "goodpractice4agents.md", package = "goodpractice"
     )
     if (!file.exists(src)) {
-        stop("File ", src, " not found.", call. = FALSE)
+        cli::cli_abort("File {.file {src}} not found.")
     }
     if (!file.copy(src, path)) {
-        stop("Failed to copy file to ", path, ".", call. = FALSE)
+        cli::cli_abort("Failed to copy file to {.file {path}}.")
     }
 
     invisible(path)

--- a/inst/skills/goodpractice4agents.md
+++ b/inst/skills/goodpractice4agents.md
@@ -1,3 +1,9 @@
+---
+name: goodpractice4agents
+description: Use the goodpractice R package to identify package issues, then repair them. Trigger whenever an agent is asked to fix, clean up, reduce, or pass goodpractice, lintr, or R CMD check failures in an R package, or to bring a package up to good-practice standards.
+compatibility: Requires the goodpractice R package installed, with read and write access within an R package repository.
+---
+
 # Fix issues identified by 'goodpractice' package
 
 **AGENT** These are instructions for you to modify the R package code in the
@@ -6,8 +12,10 @@ several categories (`groups`) of common issues in R package development. Each
 "issue" is called a failure, and your job is to modify the code to ensure as
 few failures as possible.
 
-The package you are checking should only ever be loaded with
-`devtools::load_all()`. Do not ever use `R CMD install`.
+Only ever load the package you are checking with `devtools::load_all()`, never
+`R CMD install`. `load_all()` reflects your in-progress edits immediately
+without a build step, so each re-check sees your latest changes; an installed
+copy would mask them until rebuilt.
 
 ## Important Note
 
@@ -21,8 +29,10 @@ need to be left as is, and consequently fail. Similar kinds of subtleties will
 apply to many other linters.
 
 If a linter appears to be giving a false failure, you may append a terminal `#
-nolint` to the end of the line. You may not embed multiple lines between `#
-nolint start` and `# nolint end`.
+nolint` to the end of the line. Avoid wrapping blocks between `# nolint start`
+and `# nolint end`: a terminal `# nolint` suppresses exactly one line you have
+judged, whereas a start/end block silently mutes every linter across a region,
+which is how genuine issues get hidden.
 
 ## Questions for user
 
@@ -63,10 +73,10 @@ with all changes (n)?_
 **The following checks are to be run for each `group` in `groups`:**
 
 4. Run `g <- gp(checks = checks_by_group(group))`
-5: Export checks to temp JSON file: `file <- tempfile(fileext = ".json"); export_json(g, file)`.
-6: Read all failures as `failures <- jsonlite::read_json(f)$failures` (AGENT:
-   Use your own tools to read this JSON file): The name of each item in
-   `failure` is called `nm` from here on. As you progress through the groups,
+5. Export checks to a temp JSON file: `file <- tempfile(fileext = ".json"); export_json(g, file)`.
+6. Read all failures as `failures <- jsonlite::read_json(file)$failures` (AGENT:
+   use your own tools to read this JSON file). The name of each item in
+   `failures` is called `nm` from here on. As you progress through the groups,
    keep tallies of numbers of failures in each group, and the total across all
    groups.
 
@@ -75,7 +85,7 @@ with all changes (n)?_
 7. Get description of failure and recommended fix with `describe_check(nm)`
 8. For each `instance` of that failure type, extract `filename` and `line`.
     8a. If `filename` is in a location ignored by `.Rbuildignore`, ignore that
-        failure and proceed to next `instace`.
+        failure and proceed to next `instance`.
     8b. If `filename` is in `man/` directory and package uses `roxygen2`
         (indicated in `DESCRIPTION` file), then do not edit `man/` files
         directly, but edit at source in `R/`, and run `roxygen2::roxygenise()`
@@ -108,7 +118,9 @@ excluded groups:
 
 14. Repeat steps 4 - 13 for `gp(checks=checks_by_group(g))` for each of the
     three remaining groups, `g = c("covr", "cyclocomp", "rcmdcheck")`. Execute
-    all steps for each single group.
+    all steps for each single group. (`revdep` was excluded in step 1 and is
+    deliberately not re-run here: it checks reverse dependencies, which is slow,
+    network-dependent, and outside the scope of fixing this package's own code.)
 
 ### Final steps
 

--- a/man/write_gp4agents.Rd
+++ b/man/write_gp4agents.Rd
@@ -8,15 +8,16 @@ use this package.}
 write_gp4agents(path = ".")
 }
 \arguments{
-\item{path}{Local path where file should be extracted.}
+\item{path}{Local path where the file should be written. If \code{path} is
+an existing directory, the file is written as \code{goodpractice4agents.md}
+within it; otherwise \code{path} is treated as the full target file name.}
 }
 \value{
-(Invisibly) Full path to file.
-\code{FALSE}.
+(Invisibly) the full path to the written file.
 }
 \description{
 The 'goodpractice4agents.md' file contains sufficient instructions for most
-AI \%agents to edit package code so that it passes most 'goodpractice'
+AI agents to edit package code so that it passes most 'goodpractice'
 checks. The file can be directly edited and tweaked for personal use cases.
 An agent can be instructed to simply "run the file goodpractice4agents.md".
 The file can also be moved to any local agent's \code{skills/} directory to
@@ -28,4 +29,5 @@ downloaded from GitHub at
 path <- file.path(tempdir(), "skill.md")
 f <- write_gp4agents(path)
 file.exists(f)
+unlink(f)
 }

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -66,3 +66,11 @@ test_that("export_json pretty-prints when requested", {
   )
   expect_gt(length(content), 1)
 })
+
+test_that("export_json works for a single non-description check group", {
+  y <- gp(bad1, checks = checks_by_group("lintr"))
+  tmp <- withr::local_tempfile(fileext = ".json")
+  export_json(y, file = tmp)
+  obj <- jsonlite::fromJSON(tmp)
+  expect_identical(obj$package, "badpackage")
+})

--- a/tests/testthat/test-write-gp4agents.R
+++ b/tests/testthat/test-write-gp4agents.R
@@ -1,0 +1,57 @@
+test_that("write_gp4agents writes to a full file path", {
+  tmp <- withr::local_tempdir()
+  path <- file.path(tmp, "skill.md")
+  f <- write_gp4agents(path)
+  expect_identical(f, path)
+  expect_true(file.exists(path))
+})
+
+test_that("write_gp4agents returns the path invisibly", {
+  tmp <- withr::local_tempdir()
+  path <- file.path(tmp, "skill.md")
+  expect_invisible(write_gp4agents(path))
+})
+
+test_that("write_gp4agents writes into an existing directory", {
+  tmp <- withr::local_tempdir()
+  f <- write_gp4agents(tmp)
+  expect_identical(f, file.path(tmp, "goodpractice4agents.md"))
+  expect_true(file.exists(f))
+})
+
+test_that("write_gp4agents defaults to the working directory", {
+  tmp <- withr::local_tempdir()
+  withr::local_dir(tmp)
+  write_gp4agents()
+  expect_true(file.exists(file.path(tmp, "goodpractice4agents.md")))
+})
+
+test_that("write_gp4agents errors when the target file already exists", {
+  tmp <- withr::local_tempdir()
+  path <- file.path(tmp, "skill.md")
+  write_gp4agents(path)
+  expect_error(write_gp4agents(path), "already exists")
+})
+
+test_that("write_gp4agents errors when the parent directory is missing", {
+  tmp <- withr::local_tempdir()
+  path <- file.path(tmp, "nope", "skill.md")
+  expect_error(write_gp4agents(path), "does not exist")
+})
+
+test_that("written file matches the packaged source", {
+  tmp <- withr::local_tempdir()
+  f <- write_gp4agents(file.path(tmp, "skill.md"))
+  src <- system.file(
+    "skills",
+    "goodpractice4agents.md",
+    package = "goodpractice"
+  )
+  expect_identical(readLines(f), readLines(src))
+})
+
+test_that("learn_gp_skill prints the bundled skill file", {
+  out <- capture.output(learn_gp_skill())
+  expect_gt(length(out), 10)
+  expect_true(any(grepl("goodpractice", out)))
+})


### PR DESCRIPTION
Follow-up fixes for #312, branched off `agents` so they're reviewable on their own and can be merged into the PR branch.

## Summary

Empirically tested the skill (a subagent following it fixed `inst/bad1` 11→0, preserving tests/vignettes and loading only via `load_all`). That run surfaced a real `export_json()` bug, and code review surfaced a broken default in `write_gp4agents()`. This branch fixes both plus the skill-file nits.

### `write_gp4agents()`
- Reorder the dir-vs-file checks so the documented default `path = "."` works. `file.exists(".")` is always `TRUE`, so the old code always errored with *"File . already exists"* and the `dir.exists()` branch was unreachable.
- `.call` → `call.` typo; return `invisible(path)`; check the `file.copy()` result; clean the malformed `@return` (orphan `\code{FALSE}`), `@param`, and `AI %agents` typo.

### `export_json()` (root cause behind a skill-workflow failure)
- Read the package name from the always-populated `gp$package` instead of `gp$description$get("Package")`, which threw *"attempt to apply non-function"* whenever the checks excluded the `description` group — i.e. most of the per-group runs the skill prescribes in steps 5–6. Reproduced on installed 1.1.0 and dev.

### `inst/agents/goodpractice4agents.md`
- Add YAML skill frontmatter (`name`/`description`/`compatibility`) so it's discoverable as a skill.
- Explain the `load_all`/`nolint` guidance rather than bare prohibitions.
- Fix `5:`/`6:` list markers (they broke the ordered list), the `f`/`file` variable mismatch in step 6, the `instace` typo, and document why `revdep` is excluded from the re-run.

## Test plan
- `testthat::test_file("tests/testthat/test-write-gp4agents.R")` — 7 new tests, incl. the previously-broken default path. Green.
- `testthat::test_file("tests/testthat/test-api.R")` — incl. new `export_json()` regression test for a non-`description` group. Green.
- `man/write_gp4agents.Rd` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)