### PR TITLE
Use cli::cli_warn() in ts_parse()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 - Fix bug in check group exclusions through env vars, and update vignette.
 - Fix prep assignment to check groups for two checks (revdep + 1 tidyverse), including attaching "namespace" prep only internally to one of those so full tidyverse prep stage is only run for that group.
 - Fix bug in printing some check results that would produce an error caused by invalid marker types (#304; thanks to @JesseAlderliesten).
+- Convert the remaining base `warning()` in `ts_parse()` to `cli::cli_warn()`, completing the package-wide move to cli messaging.
 
 ---
 

--- a/R/treesitter.R
+++ b/R/treesitter.R
@@ -74,7 +74,7 @@ ts_parse <- function(path, exclude_path = character(), encoding = "UTF-8") {
     code <- tryCatch(
       read_source_file(f, encoding),
       error = function(e) {
-        warning("Could not read ", f, ": ", conditionMessage(e), call. = FALSE)
+        cli::cli_warn("Could not read {.file {f}}: {conditionMessage(e)}")
         NULL
       }
     )


### PR DESCRIPTION
Completes the package-wide move to cli messaging by converting the last base `warning()` call.

`ts_parse()`'s unreadable-source-file handler still used `warning(..., call. = FALSE)`. Replaced with `cli::cli_warn()` and `{.file}` markup, matching the existing cli usage in `prep_utils.R`, `gp.R`, `lists.R`, etc.

Behaviour-preserving: same trigger, equivalent message (`Could not read '<file>': <reason>`).

The `stop("offline")` in `prep_urlchecker.R` is intentionally left as base — it's a `try()` sentinel, not user-facing.

## Test plan
- `testthat::test_file("tests/testthat/test-treesitter.R")` — 41 tests, green.
- Verified the `cli_warn` renders: `Could not read 'fake.R': boom`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)